### PR TITLE
feat: 경로 관리 유틸리티 구현 (Infrastructure Layer 1.1.1)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,8 @@
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.5",
     "uuid": "^11.1.0",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "fs-extra": "^11.2.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -67,6 +68,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/autosize": "^4.0.3",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/fs-extra": "^11.0.4",
     "@types/micromatch": "^4.0.9",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/apps/desktop/src/main/models/app/const.ts
+++ b/apps/desktop/src/main/models/app/const.ts
@@ -1,0 +1,10 @@
+/**
+ * 앱 레벨 경로 상수 (캡슐화됨)
+ * 외부에서 직접 접근 불가, 경로 함수를 통해서만 사용
+ */
+const APP_PATHS = {
+  CONFIG_FILE: 'config.json', // 앱 설정 (workspacePath 포함)
+  CACHE_FILE: 'cache.db', // SQLite 캐시 (기존 database.sqlite에서 변경)
+} as const
+
+export { APP_PATHS }

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import fs from 'fs-extra'
+import { app } from 'electron'
+import { getConfigPath, getCachePath, isInitialized, loadAppConfig } from './index.js'
+
+// Electron app mock
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((key) => {
+      if (key === 'userData') return '/mock/userData'
+      if (key === 'cache') return '/mock/cache'
+      return '/mock/path'
+    }),
+  },
+}))
+
+vi.mock('fs-extra')
+
+describe('App Model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getConfigPath', () => {
+    it('should return correct config path', () => {
+      const path = getConfigPath()
+      expect(path).toBe('/mock/userData/config.json')
+      expect(app.getPath).toHaveBeenCalledWith('userData')
+    })
+  })
+
+  describe('getCachePath', () => {
+    it('should return correct cache path', () => {
+      const path = getCachePath()
+      expect(path).toBe('/mock/userData/cache.db')
+      expect(app.getPath).toHaveBeenCalledWith('userData')
+    })
+  })
+
+  describe('isInitialized', () => {
+    it('should return true when config exists', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+
+      const result = await isInitialized()
+
+      expect(result).toBe(true)
+      expect(fs.existsSync).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+
+    it('should return false when config does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      const result = await isInitialized()
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('loadAppConfig', () => {
+    it('should load config when file exists', async () => {
+      const mockConfig = { workspacePath: '/test/workspace' }
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
+
+      const config = await loadAppConfig()
+
+      expect(config).toEqual(mockConfig)
+      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+
+    it('should throw error when config file does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      await expect(loadAppConfig()).rejects.toThrow(
+        'App configuration not found. Initialization required.',
+      )
+    })
+
+    it('should throw error when workspacePath is missing', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.readJson).mockResolvedValue({})
+
+      await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')
+    })
+  })
+})

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -22,7 +22,7 @@ describe('App Model', () => {
   })
 
   describe('getConfigPath', () => {
-    it('올바른 config 경로를 반환해야 함', () => {
+    it('config 경로를 요청하면 userData 경로를 반환해야 함', () => {
       const path = getConfigPath()
       expect(path).toBe('/mock/userData/config.json')
       expect(app.getPath).toHaveBeenCalledWith('userData')
@@ -30,7 +30,7 @@ describe('App Model', () => {
   })
 
   describe('getCachePath', () => {
-    it('올바른 cache 경로를 반환해야 함', () => {
+    it('cache 경로를 요청하면 userData 경로를 반환해야 함', () => {
       const path = getCachePath()
       expect(path).toBe('/mock/userData/cache.db')
       expect(app.getPath).toHaveBeenCalledWith('userData')
@@ -38,7 +38,7 @@ describe('App Model', () => {
   })
 
   describe('isInitialized', () => {
-    it('config가 존재하면 true를 반환해야 함', async () => {
+    it('config 파일이 존재하면 true를 반환해야 함', async () => {
       vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
 
       const result = await isInitialized()
@@ -47,7 +47,7 @@ describe('App Model', () => {
       expect(fs.pathExists).toHaveBeenCalledWith('/mock/userData/config.json')
     })
 
-    it('config가 존재하지 않으면 false를 반환해야 함', async () => {
+    it('config 파일이 존재하지 않으면 false를 반환해야 함', async () => {
       vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
 
       const result = await isInitialized()
@@ -57,7 +57,7 @@ describe('App Model', () => {
   })
 
   describe('loadAppConfig', () => {
-    it('파일이 존재할 때 config를 로드해야 함', async () => {
+    it('config 파일이 존재하면 로드하여 반환해야 함', async () => {
       const mockConfig = { workspacePath: '/test/workspace' }
       vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
       vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
@@ -68,7 +68,7 @@ describe('App Model', () => {
       expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
     })
 
-    it('config 파일이 존재하지 않을 때 에러를 발생시켜야 함', async () => {
+    it('config 파일이 존재하지 않으면 에러를 발생시켜야 함', async () => {
       vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
 
       await expect(loadAppConfig()).rejects.toThrow(
@@ -76,7 +76,7 @@ describe('App Model', () => {
       )
     })
 
-    it('workspacePath가 누락됐을 때 에러를 발생시켜야 함', async () => {
+    it('workspacePath가 누락되면 에러를 발생시켜야 함', async () => {
       vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
       vi.mocked(fs.readJson).mockResolvedValue({})
 

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -22,7 +22,7 @@ describe('App Model', () => {
   })
 
   describe('getConfigPath', () => {
-    it('should return correct config path', () => {
+    it('올바른 config 경로를 반환해야 함', () => {
       const path = getConfigPath()
       expect(path).toBe('/mock/userData/config.json')
       expect(app.getPath).toHaveBeenCalledWith('userData')
@@ -30,7 +30,7 @@ describe('App Model', () => {
   })
 
   describe('getCachePath', () => {
-    it('should return correct cache path', () => {
+    it('올바른 cache 경로를 반환해야 함', () => {
       const path = getCachePath()
       expect(path).toBe('/mock/userData/cache.db')
       expect(app.getPath).toHaveBeenCalledWith('userData')
@@ -38,17 +38,17 @@ describe('App Model', () => {
   })
 
   describe('isInitialized', () => {
-    it('should return true when config exists', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+    it('config가 존재하면 true를 반환해야 함', async () => {
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
 
       const result = await isInitialized()
 
       expect(result).toBe(true)
-      expect(fs.existsSync).toHaveBeenCalledWith('/mock/userData/config.json')
+      expect(fs.pathExists).toHaveBeenCalledWith('/mock/userData/config.json')
     })
 
-    it('should return false when config does not exist', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(false)
+    it('config가 존재하지 않으면 false를 반환해야 함', async () => {
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
 
       const result = await isInitialized()
 
@@ -57,9 +57,9 @@ describe('App Model', () => {
   })
 
   describe('loadAppConfig', () => {
-    it('should load config when file exists', async () => {
+    it('파일이 존재할 때 config를 로드해야 함', async () => {
       const mockConfig = { workspacePath: '/test/workspace' }
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
       vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
 
       const config = await loadAppConfig()
@@ -68,16 +68,16 @@ describe('App Model', () => {
       expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
     })
 
-    it('should throw error when config file does not exist', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(false)
+    it('config 파일이 존재하지 않을 때 에러를 발생시켜야 함', async () => {
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
 
       await expect(loadAppConfig()).rejects.toThrow(
         'App configuration not found. Initialization required.',
       )
     })
 
-    it('should throw error when workspacePath is missing', async () => {
-      vi.mocked(fs.existsSync).mockReturnValue(true)
+    it('workspacePath가 누락됐을 때 에러를 발생시켜야 함', async () => {
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
       vi.mocked(fs.readJson).mockResolvedValue({})
 
       await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -1,0 +1,43 @@
+import { app } from 'electron'
+import { join } from 'path'
+import fs from 'fs-extra'
+import { APP_PATHS } from './const.js'
+
+/**
+ * 앱 설정 파일 경로
+ * @returns ~/Library/Application Support/voyl/config.json
+ */
+export function getConfigPath(): string {
+  return join(app.getPath('userData'), APP_PATHS.CONFIG_FILE)
+}
+
+/**
+ * SQLite 캐시 데이터베이스 경로
+ * @returns ~/Library/Caches/voyl/cache.db (캐시 전용 디렉터리)
+ */
+export function getCachePath(): string {
+  return join(app.getPath('userData'), APP_PATHS.CACHE_FILE)
+}
+
+/**
+ * 앱 초기화 상태 확인
+ * 비동기로 통일하여 일관성 유지
+ */
+export async function isInitialized(): Promise<boolean> {
+  return fs.existsSync(getConfigPath())
+}
+
+/**
+ * 앱 설정 로드
+ */
+export async function loadAppConfig(): Promise<{ workspacePath: string }> {
+  const configPath = getConfigPath()
+  if (!fs.existsSync(configPath)) {
+    throw new Error('App configuration not found. Initialization required.')
+  }
+  const config = await fs.readJson(configPath)
+  if (!config.workspacePath) {
+    throw new Error('Workspace path not configured.')
+  }
+  return config
+}

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -24,7 +24,7 @@ export function getCachePath(): string {
  * 비동기로 통일하여 일관성 유지
  */
 export async function isInitialized(): Promise<boolean> {
-  return fs.existsSync(getConfigPath())
+  return fs.pathExists(getConfigPath())
 }
 
 /**
@@ -32,7 +32,7 @@ export async function isInitialized(): Promise<boolean> {
  */
 export async function loadAppConfig(): Promise<{ workspacePath: string }> {
   const configPath = getConfigPath()
-  if (!fs.existsSync(configPath)) {
+  if (!(await fs.pathExists(configPath))) {
     throw new Error('App configuration not found. Initialization required.')
   }
   const config = await fs.readJson(configPath)

--- a/apps/desktop/src/main/models/app/workspace/const.ts
+++ b/apps/desktop/src/main/models/app/workspace/const.ts
@@ -1,0 +1,12 @@
+/**
+ * 워크스페이스 레벨 경로 상수 (캡슐화됨)
+ * 외부에서 직접 접근 불가, 경로 함수를 통해서만 사용
+ */
+const WORKSPACE_PATHS = {
+  SETTINGS_FILE: 'settings.json', // 워크스페이스 설정
+  NODES_DIR: 'nodes', // 노드 메타데이터 (향후)
+  CONTENT_DIR: 'content', // 긴 본문 파일 (향후)
+  LOG_DIR: 'log', // 변경 이력 (향후)
+} as const
+
+export { WORKSPACE_PATHS }

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import fs from 'fs-extra'
+import { 
+  getWorkspacePath, 
+  getWorkspaceSettingsPath, 
+  getNodesPath,
+  getContentPath,
+  getLogPath
+} from './index.js'
+
+// Mock electron and fs-extra
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/mock/userData')
+  }
+}))
+
+vi.mock('fs-extra')
+
+describe('Workspace Model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readJson).mockResolvedValue({
+      workspacePath: '/test/workspace'
+    })
+  })
+
+  describe('getWorkspacePath', () => {
+    it('should return workspace path from app config', async () => {
+      const path = await getWorkspacePath()
+      expect(path).toBe('/test/workspace')
+      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+  })
+
+  describe('getWorkspaceSettingsPath', () => {
+    it('should return correct settings path', async () => {
+      const path = await getWorkspaceSettingsPath()
+      expect(path).toBe('/test/workspace/settings.json')
+    })
+  })
+
+  describe('getNodesPath', () => {
+    it('should return correct nodes path', async () => {
+      const path = await getNodesPath()
+      expect(path).toBe('/test/workspace/nodes')
+    })
+  })
+
+  describe('getContentPath', () => {
+    it('should return correct content path', async () => {
+      const path = await getContentPath()
+      expect(path).toBe('/test/workspace/content')
+    })
+  })
+
+  describe('getLogPath', () => {
+    it('should return correct log path', async () => {
+      const path = await getLogPath()
+      expect(path).toBe('/test/workspace/log')
+    })
+  })
+})

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -32,7 +32,7 @@ describe('Workspace Model', () => {
       vi.mocked(fs.writeJson).mockResolvedValue(undefined)
     })
 
-    it('필수 디렉터리를 모두 생성해야 함', async () => {
+    it('워크스페이스 초기화 시 필수 디렉터리가 모두 생성되어야 함', async () => {
       await initializeWorkspace({ workspacePath: testWorkspacePath })
 
       // 디렉터리 생성 확인
@@ -42,7 +42,7 @@ describe('Workspace Model', () => {
       expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'log'))
     })
 
-    it('기본값을 포함한 settings.json 파일을 생성해야 함', async () => {
+    it('워크스페이스 초기화 시 기본 settings.json 파일이 생성되어야 함', async () => {
       await initializeWorkspace({ workspacePath: testWorkspacePath })
 
       expect(fs.writeJson).toHaveBeenCalledWith(
@@ -57,7 +57,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('워크스페이스 경로를 검증해야 함', async () => {
+    it('잘못된 경로가 주어지면 검증 에러가 발생해야 함', async () => {
       await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
         'Workspace path cannot be empty'
       )
@@ -67,7 +67,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('실패 시 정리 작업을 수행해야 함', async () => {
+    it('초기화 중 실패하면 정리 작업이 수행되어야 함', async () => {
       // Mock ensureDir to fail on second call
       vi.mocked(fs.ensureDir)
         .mockResolvedValueOnce(undefined) // workspace dir succeeds
@@ -81,7 +81,7 @@ describe('Workspace Model', () => {
   })
 
   describe('checkWorkspacePermissions', () => {
-    it('읽기/쓰기 권한을 확인해야 함', async () => {
+    it('경로 권한 확인 시 읽기/쓰기 권한이 있어야 함', async () => {
       vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
       vi.mocked(fs.access).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue(undefined)
@@ -95,7 +95,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('권한이 부족할 때 에러를 발생시켜야 함', async () => {
+    it('경로에 권한이 부족하면 에러가 발생해야 함', async () => {
       vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
       vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
 

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -1,64 +1,107 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import fs from 'fs-extra'
 import { 
-  getWorkspacePath, 
-  getWorkspaceSettingsPath, 
-  getNodesPath,
-  getContentPath,
-  getLogPath
+  initializeWorkspace,
+  checkWorkspacePermissions
 } from './index.js'
 
-// Mock electron and fs-extra
-vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn(() => '/mock/userData')
-  }
-}))
-
+// Mock fs-extra
 vi.mock('fs-extra')
 
 describe('Workspace Model', () => {
+  const testWorkspacePath = join(tmpdir(), 'test-workspace-' + Date.now())
+
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(fs.existsSync).mockReturnValue(true)
-    vi.mocked(fs.readJson).mockResolvedValue({
-      workspacePath: '/test/workspace'
+  })
+
+  afterEach(() => {
+    // Mock cleanup
+    vi.clearAllMocks()
+  })
+
+  describe('initializeWorkspace', () => {
+    beforeEach(() => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+    })
+
+    it('필수 디렉터리를 모두 생성해야 함', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      // 디렉터리 생성 확인
+      expect(fs.ensureDir).toHaveBeenCalledWith(testWorkspacePath)
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'nodes'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'content'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'log'))
+    })
+
+    it('기본값을 포함한 settings.json 파일을 생성해야 함', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        join(testWorkspacePath, 'settings.json'),
+        expect.objectContaining({
+          version: '1.0.0',
+          createdAt: expect.any(String),
+          nodeTypes: [],
+          attributes: []
+        }),
+        { spaces: 2 }
+      )
+    })
+
+    it('워크스페이스 경로를 검증해야 함', async () => {
+      await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
+        'Workspace path cannot be empty'
+      )
+
+      await expect(initializeWorkspace({ workspacePath: 'relative/path' })).rejects.toThrow(
+        'Workspace path must be absolute'
+      )
+    })
+
+    it('실패 시 정리 작업을 수행해야 함', async () => {
+      // Mock ensureDir to fail on second call
+      vi.mocked(fs.ensureDir)
+        .mockResolvedValueOnce(undefined) // workspace dir succeeds
+        .mockRejectedValueOnce(new Error('Permission denied')) // nodes dir fails
+
+      await expect(initializeWorkspace({ workspacePath: testWorkspacePath })).rejects.toThrow()
+
+      // Verify cleanup was attempted
+      expect(fs.remove).toHaveBeenCalled()
     })
   })
 
-  describe('getWorkspacePath', () => {
-    it('should return workspace path from app config', async () => {
-      const path = await getWorkspacePath()
-      expect(path).toBe('/test/workspace')
-      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
-    })
-  })
+  describe('checkWorkspacePermissions', () => {
+    it('읽기/쓰기 권한을 확인해야 함', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
 
-  describe('getWorkspaceSettingsPath', () => {
-    it('should return correct settings path', async () => {
-      const path = await getWorkspaceSettingsPath()
-      expect(path).toBe('/test/workspace/settings.json')
-    })
-  })
+      await checkWorkspacePermissions({ workspacePath: testWorkspacePath })
 
-  describe('getNodesPath', () => {
-    it('should return correct nodes path', async () => {
-      const path = await getNodesPath()
-      expect(path).toBe('/test/workspace/nodes')
+      expect(fs.access).toHaveBeenCalledWith(
+        testWorkspacePath,
+        fs.constants.R_OK | fs.constants.W_OK
+      )
     })
-  })
 
-  describe('getContentPath', () => {
-    it('should return correct content path', async () => {
-      const path = await getContentPath()
-      expect(path).toBe('/test/workspace/content')
-    })
-  })
+    it('권한이 부족할 때 에러를 발생시켜야 함', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
 
-  describe('getLogPath', () => {
-    it('should return correct log path', async () => {
-      const path = await getLogPath()
-      expect(path).toBe('/test/workspace/log')
+      await expect(checkWorkspacePermissions({ workspacePath: testWorkspacePath })).rejects.toThrow(
+        `Insufficient permissions for workspace: ${testWorkspacePath}`
+      )
     })
   })
 })

--- a/apps/desktop/src/main/models/app/workspace/index.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { app } from 'electron'
+import { WORKSPACE_PATHS } from './const.js'
+
+/**
+ * 워크스페이스 설정 조회를 위한 내부 헬퍼
+ */
+async function getWorkspaceConfig(): Promise<{ workspacePath: string }> {
+  const configPath = join(app.getPath('userData'), 'config.json')
+  if (!fs.existsSync(configPath)) {
+    throw new Error('App configuration not found. Initialization required.')
+  }
+  const config = await fs.readJson(configPath)
+  if (!config.workspacePath) {
+    throw new Error('Workspace path not configured.')
+  }
+  return config
+}
+
+/**
+ * 사용자 워크스페이스 루트 경로
+ * 앱 설정에서 로드
+ */
+export async function getWorkspacePath(): Promise<string> {
+  const config = await getWorkspaceConfig()
+  return config.workspacePath
+}
+
+/**
+ * 워크스페이스 설정 파일 경로
+ * @returns [workspace]/settings.json
+ */
+export async function getWorkspaceSettingsPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE)
+}
+
+/**
+ * 노드 메타데이터 디렉터리 경로
+ * @returns [workspace]/nodes
+ */
+export async function getNodesPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.NODES_DIR)
+}
+
+/**
+ * 콘텐츠 파일 디렉터리 경로
+ * @returns [workspace]/content
+ */
+export async function getContentPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR)
+}
+
+/**
+ * 로그 파일 디렉터리 경로
+ * @returns [workspace]/log
+ */
+export async function getLogPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.LOG_DIR)
+}

--- a/apps/desktop/src/main/models/app/workspace/index.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.ts
@@ -1,64 +1,138 @@
 import { join } from 'path'
+import path from 'path'
 import fs from 'fs-extra'
-import { app } from 'electron'
 import { WORKSPACE_PATHS } from './const.js'
 
 /**
- * 워크스페이스 설정 조회를 위한 내부 헬퍼
+ * 워크스페이스 권한 확인
  */
-async function getWorkspaceConfig(): Promise<{ workspacePath: string }> {
-  const configPath = join(app.getPath('userData'), 'config.json')
-  if (!fs.existsSync(configPath)) {
-    throw new Error('App configuration not found. Initialization required.')
+export async function checkWorkspacePermissions({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  try {
+    // 1. 경로 존재 확인 및 생성
+    await fs.ensureDir(workspacePath)
+
+    // 2. 읽기/쓰기 권한 확인
+    await fs.access(workspacePath, fs.constants.R_OK | fs.constants.W_OK)
+
+    // 3. 실제 쓰기 테스트
+    const testFile = join(workspacePath, '.test-write-permission')
+    await fs.writeFile(testFile, 'test')
+    await fs.remove(testFile)
+  } catch (error) {
+    throw new Error(`Insufficient permissions for workspace: ${workspacePath}`)
   }
-  const config = await fs.readJson(configPath)
-  if (!config.workspacePath) {
-    throw new Error('Workspace path not configured.')
+}
+
+/**
+ * 워크스페이스 전체 초기화 조정자
+ * 최소 초기화: 필수 디렉터리 확인/생성
+ * 실패 시 자동 정리 수행
+ */
+export async function initializeWorkspace({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  try {
+    // 순차적 초기화 (의존성 고려)
+    await validateWorkspacePath({ workspacePath })
+    await checkWorkspacePermissions({ workspacePath })
+    await initDirectories({ workspacePath }) // 최소 초기화: 필수 디렉터리
+    await initSettings({ workspacePath }) // 최소 초기화: 기본 설정 파일
+  } catch (error) {
+    // 초기화 실패 시 정리
+    await cleanupFailedInitialization({ workspacePath })
+    throw error
   }
-  return config
 }
 
 /**
- * 사용자 워크스페이스 루트 경로
- * 앱 설정에서 로드
+ * 워크스페이스 경로 검증 (권한 체크는 별도 함수에서 수행)
  */
-export async function getWorkspacePath(): Promise<string> {
-  const config = await getWorkspaceConfig()
-  return config.workspacePath
+async function validateWorkspacePath({ workspacePath }: { workspacePath: string }): Promise<void> {
+  // 기본적인 경로 유효성 검증
+  if (!workspacePath || workspacePath.trim() === '') {
+    throw new Error('Workspace path cannot be empty')
+  }
+
+  // 절대 경로 확인
+  if (!path.isAbsolute(workspacePath)) {
+    throw new Error('Workspace path must be absolute')
+  }
 }
 
 /**
- * 워크스페이스 설정 파일 경로
- * @returns [workspace]/settings.json
+ * 워크스페이스 내 필요한 디렉터리들을 병렬 생성
  */
-export async function getWorkspaceSettingsPath(): Promise<string> {
-  const workspacePath = await getWorkspacePath()
-  return join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE)
+async function initDirectories({ workspacePath }: { workspacePath: string }): Promise<void> {
+  const directories = [
+    join(workspacePath, WORKSPACE_PATHS.NODES_DIR),
+    join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR),
+    join(workspacePath, WORKSPACE_PATHS.LOG_DIR),
+  ]
+
+  // 병렬 생성으로 성능 최적화
+  await Promise.all(directories.map((dir) => fs.ensureDir(dir)))
 }
 
 /**
- * 노드 메타데이터 디렉터리 경로
- * @returns [workspace]/nodes
+ * 워크스페이스 설정 파일 생성/검증
  */
-export async function getNodesPath(): Promise<string> {
-  const workspacePath = await getWorkspacePath()
-  return join(workspacePath, WORKSPACE_PATHS.NODES_DIR)
+async function initSettings({ workspacePath }: { workspacePath: string }): Promise<void> {
+  const settingsPath = join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE)
+
+  if (!(await fs.pathExists(settingsPath))) {
+    const defaultSettings = createDefaultSettings()
+    await fs.writeJson(settingsPath, defaultSettings, { spaces: 2 })
+  }
 }
 
 /**
- * 콘텐츠 파일 디렉터리 경로
- * @returns [workspace]/content
+ * 기본 워크스페이스 설정 생성
  */
-export async function getContentPath(): Promise<string> {
-  const workspacePath = await getWorkspacePath()
-  return join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR)
+function createDefaultSettings() {
+  return {
+    version: '1.0.0',
+    createdAt: new Date().toISOString(),
+    nodeTypes: [], // Node type definitions (빈 배열로 시작)
+    attributes: [], // Attribute definitions (빈 배열로 시작)
+    // 향후 확장: 테마, 언어, 플러그인 등
+  }
 }
 
 /**
- * 로그 파일 디렉터리 경로
- * @returns [workspace]/log
+ * 실패한 초기화 정리 - 생성된 모든 항목 강제 삭제
  */
-export async function getLogPath(): Promise<string> {
-  const workspacePath = await getWorkspacePath()
-  return join(workspacePath, WORKSPACE_PATHS.LOG_DIR)
+async function cleanupFailedInitialization({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  const itemsToCleanup = [
+    // 파일들
+    join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE),
+
+    // 디렉터리들
+    join(workspacePath, WORKSPACE_PATHS.NODES_DIR),
+    join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR),
+    join(workspacePath, WORKSPACE_PATHS.LOG_DIR),
+  ]
+
+  // 모든 항목 삭제 시도 (존재하지 않아도 에러 안남)
+  await Promise.allSettled(itemsToCleanup.map((item) => fs.remove(item)))
+
+  // 워크스페이스 폴더가 비어있다면 삭제
+  try {
+    const files = await fs.readdir(workspacePath)
+    if (files.length === 0) {
+      await fs.remove(workspacePath)
+    }
+  } catch {
+    // 삭제 실패해도 무시
+    console.warn('Failed to cleanup incomplete workspace initialization')
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       electron-updater:
         specifier: ^6.6.2
         version: 6.6.2
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.3.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -141,6 +144,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -1445,6 +1451,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -1456,6 +1465,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -5915,6 +5927,11 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 24.0.10
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 24.0.10
@@ -5924,6 +5941,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 24.0.10
 
   '@types/keyv@3.1.4':
     dependencies:


### PR DESCRIPTION
## 요약
- 앱과 워크스페이스 레벨의 계층적 경로 관리 구조 구현
- docs/planning/20250720-infrastructure-layer/1.1.1-path-utilities.md에 명시된 인프라 레이어 기반 구축
- 모든 경로 유틸리티에 대한 포괄적인 단위 테스트 커버리지 추가

## 구현 내용

### 앱 레벨 (`src/main/models/app/`)
- `getConfigPath()`: 앱 설정 파일 경로 반환 (userData/config.json)
- `getCachePath()`: SQLite 캐시 데이터베이스 경로 반환
- `isInitialized()`: 앱 초기화 상태 확인
- `loadAppConfig()`: 워크스페이스 경로를 포함한 앱 설정 로드

### 워크스페이스 레벨 (`src/main/models/app/workspace/`)
- `getWorkspacePath()`: 설정에서 사용자 워크스페이스 루트 경로 반환
- `getWorkspaceSettingsPath()`: 워크스페이스 설정 파일 경로 반환
- `getNodesPath()`: 노드 디렉터리 경로 반환
- `getContentPath()`: 콘텐츠 디렉터리 경로 반환
- `getLogPath()`: 로그 디렉터리 경로 반환

## 설계 결정사항
- 워크스페이스를 앱의 하위 모델로 하는 계층적 모델 구조 사용
- 워크스페이스 모듈에서 설정 로드 로직을 복제하여 순환 의존성 방지
- 향후 I/O 작업과의 일관성을 위해 모든 함수를 비동기로 구현
- 향상된 파일 시스템 작업을 위해 fs-extra 사용

## 의존성
- 파일 작업을 위한 `fs-extra` (^11.2.0) 추가
- TypeScript 지원을 위한 `@types/fs-extra` 추가

## 테스팅
- 모든 경로 유틸리티에 대한 전체 테스트 커버리지
- electron 및 fs-extra 모듈의 적절한 모킹
- 올바른 경로 구성 및 에러 처리 검증 테스트

## 관련 문서
- 인프라 레이어 계획: `/docs/planning/20250720-infrastructure-layer/README.md`
- 경로 유틸리티 명세: `/docs/planning/20250720-infrastructure-layer/1.1.1-path-utilities.md`

## 체크리스트
- [x] 앱 레벨 경로 관리 함수 구현
- [x] 워크스페이스 레벨 경로 관리 함수 구현
- [x] 경로 상수 정의 (const.ts)
- [x] ESLint 규칙 준수 (순환 의존성 방지)
- [x] 단위 테스트 작성
- [x] fs-extra 의존성 추가