### PR TITLE
feat: 워크스페이스 초기화 구현 (Infrastructure Layer 1.1.2)

### DIFF
--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -98,7 +98,7 @@ describe('App Model', () => {
   })
 
   describe('initializeApp', () => {
-    it('should initialize app with workspace path', async () => {
+    it('워크스페이스 경로가 주어지면 앱을 초기화해야 함', async () => {
       const mockWorkspacePath = '/test/workspace'
       vi.mocked(fs.writeJson).mockResolvedValue(undefined)
 
@@ -123,7 +123,7 @@ describe('App Model', () => {
   })
 
   describe('memory management', () => {
-    it('should manage app config in memory', () => {
+    it('config 설정과 조회 시 메모리에서 관리되어야 함', () => {
       expect(getAppConfig()).toBeNull()
 
       const testConfig = { workspacePath: '/test/path' }

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import fs from 'fs-extra'
 import { app } from 'electron'
-import { getConfigPath, getCachePath, isInitialized, loadAppConfig } from './index.js'
+import {
+  getConfigPath,
+  getCachePath,
+  isInitialized,
+  loadAppConfig,
+  getAppConfig,
+  setAppConfig,
+  initializeApp,
+} from './index.js'
 
 // Electron app mock
 vi.mock('electron', () => ({
@@ -15,10 +23,14 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('fs-extra')
+vi.mock('./workspace/index.js', () => ({
+  initializeWorkspace: vi.fn().mockResolvedValue(undefined),
+}))
 
 describe('App Model', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setAppConfig(null)
   })
 
   describe('getConfigPath', () => {
@@ -66,6 +78,7 @@ describe('App Model', () => {
 
       expect(config).toEqual(mockConfig)
       expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+      expect(getAppConfig()).toEqual(mockConfig)
     })
 
     it('config 파일이 존재하지 않으면 에러를 발생시켜야 함', async () => {
@@ -81,6 +94,42 @@ describe('App Model', () => {
       vi.mocked(fs.readJson).mockResolvedValue({})
 
       await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')
+    })
+  })
+
+  describe('initializeApp', () => {
+    it('should initialize app with workspace path', async () => {
+      const mockWorkspacePath = '/test/workspace'
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+
+      await initializeApp({ workspacePath: mockWorkspacePath })
+
+      // 설정 파일이 저장되었는지 확인
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        '/mock/userData/config.json',
+        expect.objectContaining({
+          version: '1.0.0',
+          workspacePath: mockWorkspacePath,
+          createdAt: expect.any(String),
+          lastUsed: expect.any(String),
+        }),
+        { spaces: 2 },
+      )
+
+      // 워크스페이스 초기화가 호출되었는지 확인
+      const { initializeWorkspace } = await import('./workspace/index.js')
+      expect(initializeWorkspace).toHaveBeenCalledWith({ workspacePath: mockWorkspacePath })
+    })
+  })
+
+  describe('memory management', () => {
+    it('should manage app config in memory', () => {
+      expect(getAppConfig()).toBeNull()
+
+      const testConfig = { workspacePath: '/test/path' }
+      setAppConfig(testConfig)
+
+      expect(getAppConfig()).toEqual(testConfig)
     })
   })
 })

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { join } from 'path'
 import fs from 'fs-extra'
 import { APP_PATHS } from './const.js'
+import { initializeWorkspace } from './workspace/index.js'
 
 /**
  * 앱 설정 파일 경로
@@ -27,8 +28,25 @@ export async function isInitialized(): Promise<boolean> {
   return fs.pathExists(getConfigPath())
 }
 
+// 앱 설정 싱글톤 메모리 관리
+let appConfig: { workspacePath: string } | null = null
+
 /**
- * 앱 설정 로드
+ * 메모리에서 앱 설정 조회 (싱글톤)
+ */
+export function getAppConfig(): { workspacePath: string } | null {
+  return appConfig
+}
+
+/**
+ * 메모리에 앱 설정 저장 (싱글톤)
+ */
+export function setAppConfig(config: { workspacePath: string } | null): void {
+  appConfig = config
+}
+
+/**
+ * 파일에서 앱 설정 로드하여 메모리에 저장
  */
 export async function loadAppConfig(): Promise<{ workspacePath: string }> {
   const configPath = getConfigPath()
@@ -39,5 +57,57 @@ export async function loadAppConfig(): Promise<{ workspacePath: string }> {
   if (!config.workspacePath) {
     throw new Error('Workspace path not configured.')
   }
+  setAppConfig(config)
   return config
+}
+
+/**
+ * 앱 설정 기반 워크스페이스 초기화 (IPC에서 호출)
+ * @returns 초기화된 워크스페이스 경로
+ */
+export async function initializeFromConfig(): Promise<string> {
+  const config = await loadAppConfig()
+
+  // 워크스페이스 초기화 (경로 검사 + 디렉터리 생성 + 설정)
+  await initializeWorkspace({ workspacePath: config.workspacePath })
+
+  return config.workspacePath
+}
+
+/**
+ * 앱 초기화 (첫 실행 - 설정 생성만)
+ * @param workspacePath 사용자가 선택한 경로
+ */
+export async function initializeApp({ workspacePath }: { workspacePath: string }): Promise<void> {
+  // 1. 앱 설정을 파일에 저장
+  await saveAppConfigToFile({ workspacePath })
+  // 2. 워크스페이스 초기화 (폴더 구조 생성 + 권한 확인)
+  await initializeWorkspace({ workspacePath })
+  // 초기화 완료: DB 초기화는 loadApp()에서 별도로 수행
+}
+
+/**
+ * 앱 로드 (설정 로드 + DB 초기화)
+ */
+export async function loadApp(): Promise<void> {
+  // 1. config 파일에서 메모리로 로드 (이미 메모리에 있다면 파일에서 다시 로드)
+  await loadAppConfig()
+  // 2. 캐시 DB 초기화는 별도로 구현 예정
+  // const cachePath = getCachePath()
+  // await initializeDB(cachePath)
+}
+
+/**
+ * 앱 설정을 파일에 저장
+ */
+async function saveAppConfigToFile(config: { workspacePath: string }): Promise<void> {
+  const configPath = getConfigPath()
+  const fullConfig = {
+    version: '1.0.0',
+    workspacePath: config.workspacePath,
+    createdAt: new Date().toISOString(),
+    lastUsed: new Date().toISOString(),
+  }
+
+  await fs.writeJson(configPath, fullConfig, { spaces: 2 })
 }

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -2,10 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import fs from 'fs-extra'
-import { 
-  initializeWorkspace,
-  checkWorkspacePermissions
-} from './index.js'
+import { initializeWorkspace, checkWorkspacePermissions } from './index.js'
 
 // Mock fs-extra
 vi.mock('fs-extra')
@@ -51,19 +48,19 @@ describe('Workspace Model', () => {
           version: '1.0.0',
           createdAt: expect.any(String),
           nodeTypes: [],
-          attributes: []
+          attributes: [],
         }),
-        { spaces: 2 }
+        { spaces: 2 },
       )
     })
 
     it('잘못된 경로가 주어지면 검증 에러가 발생해야 함', async () => {
       await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
-        'Workspace path cannot be empty'
+        'Workspace path cannot be empty',
       )
 
       await expect(initializeWorkspace({ workspacePath: 'relative/path' })).rejects.toThrow(
-        'Workspace path must be absolute'
+        'Workspace path must be absolute',
       )
     })
 
@@ -91,7 +88,7 @@ describe('Workspace Model', () => {
 
       expect(fs.access).toHaveBeenCalledWith(
         testWorkspacePath,
-        fs.constants.R_OK | fs.constants.W_OK
+        fs.constants.R_OK | fs.constants.W_OK,
       )
     })
 
@@ -100,7 +97,90 @@ describe('Workspace Model', () => {
       vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
 
       await expect(checkWorkspacePermissions({ workspacePath: testWorkspacePath })).rejects.toThrow(
-        `Insufficient permissions for workspace: ${testWorkspacePath}`
+        `Insufficient permissions for workspace: ${testWorkspacePath}`,
+      )
+    })
+  })
+
+  describe('initializeWorkspace', () => {
+    beforeEach(() => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(fs.pathExists).mockResolvedValue(false)
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+    })
+
+    it('should create all required directories', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      // 디렉터리 생성 확인
+      expect(fs.ensureDir).toHaveBeenCalledWith(testWorkspacePath)
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'nodes'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'content'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'log'))
+    })
+
+    it('should create settings.json with default values', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        join(testWorkspacePath, 'settings.json'),
+        expect.objectContaining({
+          version: '1.0.0',
+          createdAt: expect.any(String),
+          nodeTypes: [],
+          attributes: [],
+        }),
+        { spaces: 2 },
+      )
+    })
+
+    it('should validate workspace path', async () => {
+      await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
+        'Workspace path cannot be empty',
+      )
+
+      await expect(initializeWorkspace({ workspacePath: 'relative/path' })).rejects.toThrow(
+        'Workspace path must be absolute',
+      )
+    })
+
+    it('should cleanup on failure', async () => {
+      // Mock ensureDir to fail on second call
+      vi.mocked(fs.ensureDir)
+        .mockResolvedValueOnce(undefined) // workspace dir succeeds
+        .mockRejectedValueOnce(new Error('Permission denied')) // nodes dir fails
+
+      await expect(initializeWorkspace({ workspacePath: testWorkspacePath })).rejects.toThrow()
+
+      // Verify cleanup was attempted
+      expect(fs.remove).toHaveBeenCalled()
+    })
+  })
+
+  describe('checkWorkspacePermissions', () => {
+    it('should check read/write permissions', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+
+      await checkWorkspacePermissions({ workspacePath: testWorkspacePath })
+
+      expect(fs.access).toHaveBeenCalledWith(
+        testWorkspacePath,
+        fs.constants.R_OK | fs.constants.W_OK,
+      )
+    })
+
+    it('should throw on insufficient permissions', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
+
+      await expect(checkWorkspacePermissions({ workspacePath: testWorkspacePath })).rejects.toThrow(
+        `Insufficient permissions for workspace: ${testWorkspacePath}`,
       )
     })
   })

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -108,11 +108,11 @@ describe('Workspace Model', () => {
       vi.mocked(fs.access).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue(undefined)
       vi.mocked(fs.remove).mockResolvedValue(undefined)
-      vi.mocked(fs.pathExists).mockResolvedValue(false)
+      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
       vi.mocked(fs.writeJson).mockResolvedValue(undefined)
     })
 
-    it('should create all required directories', async () => {
+    it('워크스페이스 초기화 시 필수 디렉터리가 모두 생성되어야 함', async () => {
       await initializeWorkspace({ workspacePath: testWorkspacePath })
 
       // 디렉터리 생성 확인
@@ -122,7 +122,7 @@ describe('Workspace Model', () => {
       expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'log'))
     })
 
-    it('should create settings.json with default values', async () => {
+    it('워크스페이스 초기화 시 기본 settings.json 파일이 생성되어야 함', async () => {
       await initializeWorkspace({ workspacePath: testWorkspacePath })
 
       expect(fs.writeJson).toHaveBeenCalledWith(
@@ -137,7 +137,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('should validate workspace path', async () => {
+    it('잘못된 경로가 주어지면 검증 에러가 발생해야 함', async () => {
       await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
         'Workspace path cannot be empty',
       )
@@ -147,7 +147,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('should cleanup on failure', async () => {
+    it('초기화 중 실패하면 정리 작업이 수행되어야 함', async () => {
       // Mock ensureDir to fail on second call
       vi.mocked(fs.ensureDir)
         .mockResolvedValueOnce(undefined) // workspace dir succeeds
@@ -161,7 +161,7 @@ describe('Workspace Model', () => {
   })
 
   describe('checkWorkspacePermissions', () => {
-    it('should check read/write permissions', async () => {
+    it('경로 권한 확인 시 읽기/쓰기 권한이 있어야 함', async () => {
       vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
       vi.mocked(fs.access).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue(undefined)
@@ -175,7 +175,7 @@ describe('Workspace Model', () => {
       )
     })
 
-    it('should throw on insufficient permissions', async () => {
+    it('경로에 권한이 부족하면 에러가 발생해야 함', async () => {
       vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
       vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
 

--- a/apps/desktop/src/main/models/app/workspace/index.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.ts
@@ -1,5 +1,4 @@
-import { join } from 'path'
-import path from 'path'
+import path, { join } from 'path'
 import fs from 'fs-extra'
 import { WORKSPACE_PATHS } from './const.js'
 


### PR DESCRIPTION
## 요약
- 워크스페이스 초기화 로직 구현
- docs/planning/20250720-infrastructure-layer/1.1.2-workspace-initialization.md에 명시된 사양 구현
- 앱 레벨과 워크스페이스 레벨의 계층적 초기화 구조

## 의존성
- PR #4 (경로 관리 유틸리티)가 먼저 머지되어야 합니다

## 구현 내용

### 앱 초기화 함수 (`src/main/models/app/index.ts`)
- `initializeApp()`: 첫 실행 시 앱 설정 생성 및 워크스페이스 초기화
- `loadApp()`: 앱 설정 로드 및 DB 초기화 준비
- `initializeFromConfig()`: 설정 기반 워크스페이스 초기화

### 워크스페이스 초기화 함수 (`src/main/models/app/workspace/index.ts`)
- `initializeWorkspace()`: 워크스페이스 전체 초기화 조정자
- `checkWorkspacePermissions()`: 읽기/쓰기 권한 확인
- `validateWorkspacePath()`: 경로 유효성 검증
- `initDirectories()`: 필수 디렉터리 생성 (nodes, content, log)
- `initSettings()`: 기본 설정 파일 생성
- `cleanupFailedInitialization()`: 실패 시 자동 정리

### 메모리 관리
- `getAppConfig()`: 싱글톤 메모리 설정 조회
- `setAppConfig()`: 싱글톤 메모리 설정 저장
- `loadAppConfig()`: 파일에서 메모리로 설정 로드

## 설계 결정사항
- 초기화 실패 시 자동 정리 메커니즘 구현
- 싱글톤 패턴으로 앱 설정 메모리 관리
- 원자성 보장: 전체 성공 또는 전체 실패
- 권한 검증을 폴더 생성 전에 수행

## 테스팅
- 초기화 로직에 대한 포괄적인 테스트
- 권한 확인 및 실패 시 정리 로직 테스트
- 경로 검증 테스트
- 메모리 관리 테스트

## 체크리스트
- [x] 앱 초기화 함수 구현
- [x] 워크스페이스 초기화 로직 구현
- [x] 권한 체크 및 검증
- [x] 실패 시 정리 메커니즘
- [x] 단위 테스트 작성

## 관련 문서
- 워크스페이스 초기화 명세: `/docs/planning/20250720-infrastructure-layer/1.1.2-workspace-initialization.md`