### PR TITLE
feat: IPC 핸들러 구현 (1.1.3)

### DIFF
--- a/apps/desktop/src/common/channel.const.ts
+++ b/apps/desktop/src/common/channel.const.ts
@@ -1,4 +1,11 @@
 export const CHANNELS = {
+  // App initialization channels
+  IS_INITIALIZED: '/app/is-initialized',
+  SELECT_WORKSPACE_PATH: '/app/workspace/select-path',
+  INITIALIZE_APP: '/app/initialize',
+  LOAD_APP: '/app/load',
+  
+  // Node channels
   GET_NODE_TABLE: '/nodes/table/get',
   GET_NODE: '/tree/node/get',
   GET_NODE_TITLE: '/nodes/title/get',

--- a/apps/desktop/src/main/ipc/app.test.ts
+++ b/apps/desktop/src/main/ipc/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { dialog, ipcMain } from 'electron'
+import { dialog } from 'electron'
 import { homedir } from 'os'
 import { join } from 'path'
 import registerAppHandlers from './app.js'
@@ -10,13 +10,18 @@ vi.mock('electron', () => ({
   dialog: {
     showOpenDialog: vi.fn(),
   },
-  ipcMain: {
-    handle: vi.fn(),
-  },
 }))
+
+// Mock ipcMain for testing
+const mockIpcMain = {
+  handle: vi.fn(),
+} as unknown as Electron.IpcMain
 
 // Mock os
 vi.mock('os', () => ({
+  default: {
+    homedir: vi.fn(() => '/home/user'),
+  },
   homedir: vi.fn(() => '/home/user'),
 }))
 
@@ -33,22 +38,22 @@ describe('App IPC Handlers', () => {
   })
 
   describe('registerAppHandlers', () => {
-    it('should register all app handlers', () => {
-      registerAppHandlers()
+    it('앱 핸들러 등록 시 모든 IPC 채널이 등록되어야 함', () => {
+      registerAppHandlers(mockIpcMain)
 
-      expect(ipcMain.handle).toHaveBeenCalledWith(
+      expect(mockIpcMain.handle).toHaveBeenCalledWith(
         CHANNELS.IS_INITIALIZED,
         expect.any(Function)
       )
-      expect(ipcMain.handle).toHaveBeenCalledWith(
+      expect(mockIpcMain.handle).toHaveBeenCalledWith(
         CHANNELS.SELECT_WORKSPACE_PATH,
         expect.any(Function)
       )
-      expect(ipcMain.handle).toHaveBeenCalledWith(
+      expect(mockIpcMain.handle).toHaveBeenCalledWith(
         CHANNELS.INITIALIZE_APP,
         expect.any(Function)
       )
-      expect(ipcMain.handle).toHaveBeenCalledWith(
+      expect(mockIpcMain.handle).toHaveBeenCalledWith(
         CHANNELS.LOAD_APP,
         expect.any(Function)
       )
@@ -56,15 +61,15 @@ describe('App IPC Handlers', () => {
   })
 
   describe('openDirectoryDialog', () => {
-    it('should open dialog with Documents default path', async () => {
+    it('경로 선택 시 Documents 기본 경로로 다이얼로그가 열려야 함', async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
         filePaths: ['/selected/path'],
       })
 
       // Register handlers and get the function
-      registerAppHandlers()
-      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const selectPathHandler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
       )?.[1]
 
@@ -79,14 +84,14 @@ describe('App IPC Handlers', () => {
       expect(result).toBe('/selected/path')
     })
 
-    it('should return null when dialog is canceled', async () => {
+    it('다이얼로그 취소 시 null을 반환해야 함', async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: true,
         filePaths: [],
       })
 
-      registerAppHandlers()
-      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const selectPathHandler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
       )?.[1]
 
@@ -96,12 +101,12 @@ describe('App IPC Handlers', () => {
   })
 
   describe('checkIsInitialized', () => {
-    it('should return true when app is initialized', async () => {
+    it('앱 초기화 상태 확인 시 초기화되어 있으면 true를 반환해야 함', async () => {
       const { isInitialized } = await import('../models/app/index.js')
       vi.mocked(isInitialized).mockResolvedValue(true)
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.IS_INITIALIZED
       )?.[1]
 
@@ -109,12 +114,12 @@ describe('App IPC Handlers', () => {
       expect(result).toBe(true)
     })
 
-    it('should return false on error', async () => {
+    it('앱 초기화 상태 확인 중 에러 발생 시 false를 반환해야 함', async () => {
       const { isInitialized } = await import('../models/app/index.js')
       vi.mocked(isInitialized).mockRejectedValue(new Error('Test error'))
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.IS_INITIALIZED
       )?.[1]
 
@@ -124,12 +129,12 @@ describe('App IPC Handlers', () => {
   })
 
   describe('handleInitializeApp', () => {
-    it('should initialize app successfully', async () => {
+    it('앱 초기화 요청 시 성공적으로 초기화되어야 함', async () => {
       const { initializeApp } = await import('../models/app/index.js')
       vi.mocked(initializeApp).mockResolvedValue(undefined)
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.INITIALIZE_APP
       )?.[1]
 
@@ -139,12 +144,12 @@ describe('App IPC Handlers', () => {
       expect(initializeApp).toHaveBeenCalledWith({ workspacePath: '/test/path' })
     })
 
-    it('should throw error on failure', async () => {
+    it('앱 초기화 실패 시 에러를 던져야 함', async () => {
       const { initializeApp } = await import('../models/app/index.js')
       vi.mocked(initializeApp).mockRejectedValue(new Error('Init failed'))
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.INITIALIZE_APP
       )?.[1]
 
@@ -154,12 +159,12 @@ describe('App IPC Handlers', () => {
   })
 
   describe('handleLoadApp', () => {
-    it('should load app successfully', async () => {
+    it('앱 로드 요청 시 성공적으로 로드되어야 함', async () => {
       const { loadApp } = await import('../models/app/index.js')
       vi.mocked(loadApp).mockResolvedValue(undefined)
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.LOAD_APP
       )?.[1]
 
@@ -167,12 +172,12 @@ describe('App IPC Handlers', () => {
       expect(loadApp).toHaveBeenCalled()
     })
 
-    it('should throw error on failure', async () => {
+    it('앱 로드 실패 시 에러를 던져야 함', async () => {
       const { loadApp } = await import('../models/app/index.js')
       vi.mocked(loadApp).mockRejectedValue(new Error('Load failed'))
 
-      registerAppHandlers()
-      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+      registerAppHandlers(mockIpcMain)
+      const handler = vi.mocked(mockIpcMain.handle).mock.calls.find(
         ([channel]) => channel === CHANNELS.LOAD_APP
       )?.[1]
 

--- a/apps/desktop/src/main/ipc/app.test.ts
+++ b/apps/desktop/src/main/ipc/app.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { dialog, ipcMain } from 'electron'
+import { homedir } from 'os'
+import { join } from 'path'
+import registerAppHandlers from './app.js'
+import { CHANNELS } from '../../common/channel.const.js'
+
+// Mock electron
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}))
+
+// Mock os
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}))
+
+// Mock models
+vi.mock('../models/app/index.js', () => ({
+  isInitialized: vi.fn(),
+  initializeApp: vi.fn(),
+  loadApp: vi.fn(),
+}))
+
+describe('App IPC Handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('registerAppHandlers', () => {
+    it('should register all app handlers', () => {
+      registerAppHandlers()
+
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.IS_INITIALIZED,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.SELECT_WORKSPACE_PATH,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.INITIALIZE_APP,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.LOAD_APP,
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('openDirectoryDialog', () => {
+    it('should open dialog with Documents default path', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: ['/selected/path'],
+      })
+
+      // Register handlers and get the function
+      registerAppHandlers()
+      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
+      )?.[1]
+
+      const result = await selectPathHandler?.()
+      
+      expect(dialog.showOpenDialog).toHaveBeenCalledWith({
+        properties: ['openDirectory', 'createDirectory'],
+        title: 'Select Workspace Location',
+        buttonLabel: 'Select',
+        defaultPath: join('/home/user', 'Documents'),
+      })
+      expect(result).toBe('/selected/path')
+    })
+
+    it('should return null when dialog is canceled', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: true,
+        filePaths: [],
+      })
+
+      registerAppHandlers()
+      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
+      )?.[1]
+
+      const result = await selectPathHandler?.()
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('checkIsInitialized', () => {
+    it('should return true when app is initialized', async () => {
+      const { isInitialized } = await import('../models/app/index.js')
+      vi.mocked(isInitialized).mockResolvedValue(true)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.IS_INITIALIZED
+      )?.[1]
+
+      const result = await handler?.()
+      expect(result).toBe(true)
+    })
+
+    it('should return false on error', async () => {
+      const { isInitialized } = await import('../models/app/index.js')
+      vi.mocked(isInitialized).mockRejectedValue(new Error('Test error'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.IS_INITIALIZED
+      )?.[1]
+
+      const result = await handler?.()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('handleInitializeApp', () => {
+    it('should initialize app successfully', async () => {
+      const { initializeApp } = await import('../models/app/index.js')
+      vi.mocked(initializeApp).mockResolvedValue(undefined)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.INITIALIZE_APP
+      )?.[1]
+
+      const mockEvent = {} as Electron.IpcMainInvokeEvent
+      await expect(handler?.(mockEvent, '/test/path')).resolves.not.toThrow()
+      
+      expect(initializeApp).toHaveBeenCalledWith({ workspacePath: '/test/path' })
+    })
+
+    it('should throw error on failure', async () => {
+      const { initializeApp } = await import('../models/app/index.js')
+      vi.mocked(initializeApp).mockRejectedValue(new Error('Init failed'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.INITIALIZE_APP
+      )?.[1]
+
+      const mockEvent = {} as Electron.IpcMainInvokeEvent
+      await expect(handler?.(mockEvent, '/test/path')).rejects.toThrow('Init failed')
+    })
+  })
+
+  describe('handleLoadApp', () => {
+    it('should load app successfully', async () => {
+      const { loadApp } = await import('../models/app/index.js')
+      vi.mocked(loadApp).mockResolvedValue(undefined)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.LOAD_APP
+      )?.[1]
+
+      await expect(handler?.()).resolves.not.toThrow()
+      expect(loadApp).toHaveBeenCalled()
+    })
+
+    it('should throw error on failure', async () => {
+      const { loadApp } = await import('../models/app/index.js')
+      vi.mocked(loadApp).mockRejectedValue(new Error('Load failed'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.LOAD_APP
+      )?.[1]
+
+      await expect(handler?.()).rejects.toThrow('Load failed')
+    })
+  })
+})

--- a/apps/desktop/src/main/ipc/app.ts
+++ b/apps/desktop/src/main/ipc/app.ts
@@ -1,0 +1,74 @@
+import { dialog, ipcMain } from 'electron'
+import { homedir } from 'os'
+import { join } from 'path'
+import { initializeApp, loadApp, isInitialized } from '../models/app/index.js'
+import { CHANNELS } from '../../common/channel.const.js'
+
+/**
+ * 디렉터리 선택 다이얼로그 (Documents 초기 경로)
+ */
+async function openDirectoryDialog(): Promise<string | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Select Workspace Location',
+    buttonLabel: 'Select',
+    defaultPath: join(homedir(), 'Documents'),
+  })
+
+  if (result.canceled || result.filePaths.length === 0) {
+    return null
+  }
+
+  return result.filePaths[0]
+}
+
+/**
+ * 앱 초기화 상태 확인
+ */
+async function checkIsInitialized(): Promise<boolean> {
+  try {
+    return await isInitialized()  // 비동기 함수로 통일
+  } catch (error) {
+    console.error('Failed to check initialization status:', error)
+    return false
+  }
+}
+
+/**
+ * 사용자 선택 경로로 앱 초기화 (첫 실행)
+ */
+async function handleInitializeApp(_event: Electron.IpcMainInvokeEvent, workspacePath: string): Promise<void> {
+  try {
+    await initializeApp({ workspacePath })
+  } catch (error) {
+    throw new Error((error as Error).message || 'Failed to initialize app')
+  }
+}
+
+/**
+ * 앱 로드 (일반 실행)
+ */
+async function handleLoadApp(): Promise<void> {
+  try {
+    await loadApp()
+  } catch (error) {
+    throw new Error((error as Error).message || 'Failed to load app')
+  }
+}
+
+/**
+ * 앱 관련 IPC 핸들러 등록
+ */
+export default function registerAppHandlers(): void {
+  // 앱 초기화 상태 확인
+  ipcMain.handle(CHANNELS.IS_INITIALIZED, checkIsInitialized)
+
+  // 워크스페이스 경로 선택
+  ipcMain.handle(CHANNELS.SELECT_WORKSPACE_PATH, openDirectoryDialog)
+  
+  // 앱 초기화 (첫 실행)
+  ipcMain.handle(CHANNELS.INITIALIZE_APP, handleInitializeApp)
+  
+  // 앱 로드 (일반 실행)
+  ipcMain.handle(CHANNELS.LOAD_APP, handleLoadApp)
+}

--- a/apps/desktop/src/main/ipc/app.ts
+++ b/apps/desktop/src/main/ipc/app.ts
@@ -1,4 +1,4 @@
-import { dialog, ipcMain } from 'electron'
+import { dialog } from 'electron'
 import { homedir } from 'os'
 import { join } from 'path'
 import { initializeApp, loadApp, isInitialized } from '../models/app/index.js'
@@ -27,7 +27,7 @@ async function openDirectoryDialog(): Promise<string | null> {
  */
 async function checkIsInitialized(): Promise<boolean> {
   try {
-    return await isInitialized()  // 비동기 함수로 통일
+    return await isInitialized() // 비동기 함수로 통일
   } catch (error) {
     console.error('Failed to check initialization status:', error)
     return false
@@ -37,11 +37,17 @@ async function checkIsInitialized(): Promise<boolean> {
 /**
  * 사용자 선택 경로로 앱 초기화 (첫 실행)
  */
-async function handleInitializeApp(_event: Electron.IpcMainInvokeEvent, workspacePath: string): Promise<void> {
+async function handleInitializeApp(
+  _event: Electron.IpcMainInvokeEvent,
+  workspacePath: string,
+): Promise<void> {
   try {
     await initializeApp({ workspacePath })
-  } catch (error) {
-    throw new Error((error as Error).message || 'Failed to initialize app')
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw error
+    }
+    throw new Error('Failed to initialize app')
   }
 }
 
@@ -51,24 +57,27 @@ async function handleInitializeApp(_event: Electron.IpcMainInvokeEvent, workspac
 async function handleLoadApp(): Promise<void> {
   try {
     await loadApp()
-  } catch (error) {
-    throw new Error((error as Error).message || 'Failed to load app')
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw error
+    }
+    throw new Error('Failed to load app')
   }
 }
 
 /**
  * 앱 관련 IPC 핸들러 등록
  */
-export default function registerAppHandlers(): void {
+export default function registerAppHandlers(ipcMain: Electron.IpcMain): void {
   // 앱 초기화 상태 확인
   ipcMain.handle(CHANNELS.IS_INITIALIZED, checkIsInitialized)
 
   // 워크스페이스 경로 선택
   ipcMain.handle(CHANNELS.SELECT_WORKSPACE_PATH, openDirectoryDialog)
-  
+
   // 앱 초기화 (첫 실행)
   ipcMain.handle(CHANNELS.INITIALIZE_APP, handleInitializeApp)
-  
+
   // 앱 로드 (일반 실행)
   ipcMain.handle(CHANNELS.LOAD_APP, handleLoadApp)
 }

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -3,6 +3,6 @@ import treeHandlers from './tree.js'
 import favoriteHandlers from './favorite.js'
 import registerAppHandlers from './app.js'
 
-registerAppHandlers()
+registerAppHandlers(ipcMain)
 treeHandlers(ipcMain)
 favoriteHandlers(ipcMain)

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron'
 import treeHandlers from './tree.js'
 import favoriteHandlers from './favorite.js'
+import registerAppHandlers from './app.js'
 
+registerAppHandlers()
 treeHandlers(ipcMain)
 favoriteHandlers(ipcMain)

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,8 +1,15 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 
+interface IElectronAPI {
+  isInitialized(): Promise<boolean>
+  selectWorkspacePath(): Promise<string | null>
+  initializeApp(path: string): Promise<void>
+  loadApp(): Promise<void>
+}
+
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    api: IElectronAPI
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,8 +1,14 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import { CHANNELS } from '../common/channel.const.js'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  isInitialized: () => ipcRenderer.invoke(CHANNELS.IS_INITIALIZED),
+  selectWorkspacePath: () => ipcRenderer.invoke(CHANNELS.SELECT_WORKSPACE_PATH),
+  initializeApp: (path: string) => ipcRenderer.invoke(CHANNELS.INITIALIZE_APP, path),
+  loadApp: () => ipcRenderer.invoke(CHANNELS.LOAD_APP),
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise


### PR DESCRIPTION
## 개요
인프라 레이어의 세 번째 PR입니다. 앱 초기화 관련 IPC 핸들러를 구현합니다.

## 주요 변경사항

### 1. IPC 채널 정의
- `IS_INITIALIZED`: 앱 초기화 상태 확인
- `SELECT_WORKSPACE_PATH`: 워크스페이스 경로 선택 다이얼로그
- `INITIALIZE_APP`: 앱 초기화 (첫 실행)
- `LOAD_APP`: 앱 로드 (일반 실행)

### 2. 핸들러 구현
- **앱 초기화 상태 확인**: config 파일 존재 여부로 판단
- **경로 선택**: Documents 폴더를 기본 경로로 하는 다이얼로그
- **앱 초기화**: 워크스페이스 경로 저장 및 디렉터리 구조 생성
- **앱 로드**: 기존 설정 로드 및 검증

### 3. Preload API
- Renderer 프로세스에서 사용할 수 있는 API 노출
- TypeScript 타입 정의 추가

### 4. 테스트
- 모든 핸들러에 대한 통합 테스트 작성
- 에러 처리 케이스 포함

## 의존성
- PR 1: 경로 관리 유틸리티 (`feat/path-utilities`)
- PR 2: 워크스페이스 초기화 (`feat/workspace-init`)

## 체크리스트
- [x] IPC 채널 정의
- [x] 핸들러 함수 구현
- [x] Preload API 노출
- [x] TypeScript 타입 정의
- [x] 테스트 작성 및 통과

## 다음 단계
- PR 4: 프론트엔드 UI 구현 (1.2)
- PR 5: 앱 시작 통합 (1.3)