### PR TITLE
feat: 앱 시작 통합 (1.3)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@fontsource/roboto-mono": "^5.2.6",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -45,6 +46,7 @@
     "dotenv": "^17.0.1",
     "drizzle-orm": "^0.44.2",
     "electron-updater": "^6.6.2",
+    "fs-extra": "^11.2.0",
     "lucide-react": "^0.525.0",
     "merge-refs": "^2.0.0",
     "react-hotkeys-hook": "^5.1.0",
@@ -53,8 +55,7 @@
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.5",
     "uuid": "^11.1.0",
-    "zustand": "^5.0.6",
-    "fs-extra": "^11.2.0"
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,8 @@
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.5",
     "uuid": "^11.1.0",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "fs-extra": "^11.2.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -67,6 +68,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/autosize": "^4.0.3",
     "@types/better-sqlite3": "^7.6.13",
+    "@types/fs-extra": "^11.0.4",
     "@types/micromatch": "^4.0.9",
     "@types/node": "^24.0.10",
     "@types/react": "^19.1.8",

--- a/apps/desktop/src/common/channel.const.ts
+++ b/apps/desktop/src/common/channel.const.ts
@@ -1,4 +1,11 @@
 export const CHANNELS = {
+  // App initialization channels
+  IS_INITIALIZED: '/app/is-initialized',
+  SELECT_WORKSPACE_PATH: '/app/workspace/select-path',
+  INITIALIZE_APP: '/app/initialize',
+  LOAD_APP: '/app/load',
+  
+  // Node channels
   GET_NODE_TABLE: '/nodes/table/get',
   GET_NODE: '/tree/node/get',
   GET_NODE_TITLE: '/nodes/title/get',

--- a/apps/desktop/src/main/db/connect.ts
+++ b/apps/desktop/src/main/db/connect.ts
@@ -1,17 +1,55 @@
 import Database from 'better-sqlite3'
-import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import { join } from 'path'
 import { app } from 'electron'
 
 const isDev = process.env.NODE_ENV === 'development'
 const DB_NAME = 'database.sqlite'
 
-const dbPath = isDev ? join(app.getAppPath(), DB_NAME) : join(app.getPath('userData'), DB_NAME)
+let dbInstance: BetterSQLite3Database | null = null
+let sqliteInstance: Database.Database | null = null
 
-const sqlite = new Database(dbPath)
+/**
+ * DB 연결 초기화 (지연 초기화)
+ */
+export function initializeDatabase(): void {
+  if (dbInstance) return // 이미 초기화됨
 
-sqlite.pragma('journal_mode = WAL')
+  const dbPath = isDev ? join(app.getAppPath(), DB_NAME) : join(app.getPath('userData'), DB_NAME)
+  
+  sqliteInstance = new Database(dbPath)
+  sqliteInstance.pragma('journal_mode = WAL')
+  
+  dbInstance = drizzle(sqliteInstance, {
+    logger: isDev,
+  })
+}
 
-export const db = drizzle(sqlite, {
-  logger: isDev,
+/**
+ * DB 인스턴스 가져오기
+ */
+export function getDatabase(): BetterSQLite3Database {
+  if (!dbInstance) {
+    throw new Error('Database not initialized. Call initializeDatabase() first.')
+  }
+  return dbInstance
+}
+
+/**
+ * DB 연결 종료
+ */
+export function closeDatabase(): void {
+  if (sqliteInstance) {
+    sqliteInstance.close()
+    sqliteInstance = null
+    dbInstance = null
+  }
+}
+
+// 이전 버전과의 호환성을 위한 export (점진적 마이그레이션용)
+export const db = new Proxy({} as BetterSQLite3Database, {
+  get(_target, prop) {
+    const database = getDatabase()
+    return database[prop as keyof BetterSQLite3Database]
+  }
 })

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,8 @@ import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { installExtension, REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer'
-import './db/connect.js'
+// DB 연결은 앱 초기화 후 loadApp에서 처리
+// import './db/connect.js'
 import './ipc/index.js'
 
 function createWindow(): void {
@@ -72,6 +73,17 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit()
+  }
+})
+
+// 앱 종료 전 정리 작업
+app.on('before-quit', async () => {
+  // DB 연결 종료
+  try {
+    const { closeDatabase } = await import('./db/connect.js')
+    closeDatabase()
+  } catch (error) {
+    console.error('Failed to close database:', error)
   }
 })
 

--- a/apps/desktop/src/main/ipc/app.test.ts
+++ b/apps/desktop/src/main/ipc/app.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { dialog, ipcMain } from 'electron'
+import { homedir } from 'os'
+import { join } from 'path'
+import registerAppHandlers from './app.js'
+import { CHANNELS } from '../../common/channel.const.js'
+
+// Mock electron
+vi.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}))
+
+// Mock os
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/user'),
+}))
+
+// Mock models
+vi.mock('../models/app/index.js', () => ({
+  isInitialized: vi.fn(),
+  initializeApp: vi.fn(),
+  loadApp: vi.fn(),
+}))
+
+describe('App IPC Handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('registerAppHandlers', () => {
+    it('should register all app handlers', () => {
+      registerAppHandlers()
+
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.IS_INITIALIZED,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.SELECT_WORKSPACE_PATH,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.INITIALIZE_APP,
+        expect.any(Function)
+      )
+      expect(ipcMain.handle).toHaveBeenCalledWith(
+        CHANNELS.LOAD_APP,
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('openDirectoryDialog', () => {
+    it('should open dialog with Documents default path', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: ['/selected/path'],
+      })
+
+      // Register handlers and get the function
+      registerAppHandlers()
+      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
+      )?.[1]
+
+      const result = await selectPathHandler?.()
+      
+      expect(dialog.showOpenDialog).toHaveBeenCalledWith({
+        properties: ['openDirectory', 'createDirectory'],
+        title: 'Select Workspace Location',
+        buttonLabel: 'Select',
+        defaultPath: join('/home/user', 'Documents'),
+      })
+      expect(result).toBe('/selected/path')
+    })
+
+    it('should return null when dialog is canceled', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: true,
+        filePaths: [],
+      })
+
+      registerAppHandlers()
+      const selectPathHandler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
+      )?.[1]
+
+      const result = await selectPathHandler?.()
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('checkIsInitialized', () => {
+    it('should return true when app is initialized', async () => {
+      const { isInitialized } = await import('../models/app/index.js')
+      vi.mocked(isInitialized).mockResolvedValue(true)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.IS_INITIALIZED
+      )?.[1]
+
+      const result = await handler?.()
+      expect(result).toBe(true)
+    })
+
+    it('should return false on error', async () => {
+      const { isInitialized } = await import('../models/app/index.js')
+      vi.mocked(isInitialized).mockRejectedValue(new Error('Test error'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.IS_INITIALIZED
+      )?.[1]
+
+      const result = await handler?.()
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('handleInitializeApp', () => {
+    it('should initialize app successfully', async () => {
+      const { initializeApp } = await import('../models/app/index.js')
+      vi.mocked(initializeApp).mockResolvedValue(undefined)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.INITIALIZE_APP
+      )?.[1]
+
+      const mockEvent = {} as Electron.IpcMainInvokeEvent
+      await expect(handler?.(mockEvent, '/test/path')).resolves.not.toThrow()
+      
+      expect(initializeApp).toHaveBeenCalledWith({ workspacePath: '/test/path' })
+    })
+
+    it('should throw error on failure', async () => {
+      const { initializeApp } = await import('../models/app/index.js')
+      vi.mocked(initializeApp).mockRejectedValue(new Error('Init failed'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.INITIALIZE_APP
+      )?.[1]
+
+      const mockEvent = {} as Electron.IpcMainInvokeEvent
+      await expect(handler?.(mockEvent, '/test/path')).rejects.toThrow('Init failed')
+    })
+  })
+
+  describe('handleLoadApp', () => {
+    it('should load app successfully', async () => {
+      const { loadApp } = await import('../models/app/index.js')
+      vi.mocked(loadApp).mockResolvedValue(undefined)
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.LOAD_APP
+      )?.[1]
+
+      await expect(handler?.()).resolves.not.toThrow()
+      expect(loadApp).toHaveBeenCalled()
+    })
+
+    it('should throw error on failure', async () => {
+      const { loadApp } = await import('../models/app/index.js')
+      vi.mocked(loadApp).mockRejectedValue(new Error('Load failed'))
+
+      registerAppHandlers()
+      const handler = vi.mocked(ipcMain.handle).mock.calls.find(
+        ([channel]) => channel === CHANNELS.LOAD_APP
+      )?.[1]
+
+      await expect(handler?.()).rejects.toThrow('Load failed')
+    })
+  })
+})

--- a/apps/desktop/src/main/ipc/app.test.ts
+++ b/apps/desktop/src/main/ipc/app.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { dialog, ipcMain } from 'electron'
-import { homedir } from 'os'
 import { join } from 'path'
 import registerAppHandlers from './app.js'
 import { CHANNELS } from '../../common/channel.const.js'
@@ -68,7 +67,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
       )?.[1]
 
-      const result = await selectPathHandler?.()
+      const result = await selectPathHandler?.(undefined as any)
       
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
         properties: ['openDirectory', 'createDirectory'],
@@ -90,7 +89,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.SELECT_WORKSPACE_PATH
       )?.[1]
 
-      const result = await selectPathHandler?.()
+      const result = await selectPathHandler?.(undefined as any)
       expect(result).toBeNull()
     })
   })
@@ -105,7 +104,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.IS_INITIALIZED
       )?.[1]
 
-      const result = await handler?.()
+      const result = await handler?.(undefined as any)
       expect(result).toBe(true)
     })
 
@@ -118,7 +117,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.IS_INITIALIZED
       )?.[1]
 
-      const result = await handler?.()
+      const result = await handler?.(undefined as any)
       expect(result).toBe(false)
     })
   })
@@ -163,7 +162,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.LOAD_APP
       )?.[1]
 
-      await expect(handler?.()).resolves.not.toThrow()
+      await expect(handler?.(undefined as any)).resolves.not.toThrow()
       expect(loadApp).toHaveBeenCalled()
     })
 
@@ -176,7 +175,7 @@ describe('App IPC Handlers', () => {
         ([channel]) => channel === CHANNELS.LOAD_APP
       )?.[1]
 
-      await expect(handler?.()).rejects.toThrow('Load failed')
+      await expect(handler?.(undefined as any)).rejects.toThrow('Load failed')
     })
   })
 })

--- a/apps/desktop/src/main/ipc/app.ts
+++ b/apps/desktop/src/main/ipc/app.ts
@@ -1,0 +1,74 @@
+import { dialog, ipcMain } from 'electron'
+import { homedir } from 'os'
+import { join } from 'path'
+import { initializeApp, loadApp, isInitialized } from '../models/app/index.js'
+import { CHANNELS } from '../../common/channel.const.js'
+
+/**
+ * 디렉터리 선택 다이얼로그 (Documents 초기 경로)
+ */
+async function openDirectoryDialog(): Promise<string | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ['openDirectory', 'createDirectory'],
+    title: 'Select Workspace Location',
+    buttonLabel: 'Select',
+    defaultPath: join(homedir(), 'Documents'),
+  })
+
+  if (result.canceled || result.filePaths.length === 0) {
+    return null
+  }
+
+  return result.filePaths[0]
+}
+
+/**
+ * 앱 초기화 상태 확인
+ */
+async function checkIsInitialized(): Promise<boolean> {
+  try {
+    return await isInitialized()  // 비동기 함수로 통일
+  } catch (error) {
+    console.error('Failed to check initialization status:', error)
+    return false
+  }
+}
+
+/**
+ * 사용자 선택 경로로 앱 초기화 (첫 실행)
+ */
+async function handleInitializeApp(_event: Electron.IpcMainInvokeEvent, workspacePath: string): Promise<void> {
+  try {
+    await initializeApp({ workspacePath })
+  } catch (error) {
+    throw new Error((error as Error).message || 'Failed to initialize app')
+  }
+}
+
+/**
+ * 앱 로드 (일반 실행)
+ */
+async function handleLoadApp(): Promise<void> {
+  try {
+    await loadApp()
+  } catch (error) {
+    throw new Error((error as Error).message || 'Failed to load app')
+  }
+}
+
+/**
+ * 앱 관련 IPC 핸들러 등록
+ */
+export default function registerAppHandlers(): void {
+  // 앱 초기화 상태 확인
+  ipcMain.handle(CHANNELS.IS_INITIALIZED, checkIsInitialized)
+
+  // 워크스페이스 경로 선택
+  ipcMain.handle(CHANNELS.SELECT_WORKSPACE_PATH, openDirectoryDialog)
+  
+  // 앱 초기화 (첫 실행)
+  ipcMain.handle(CHANNELS.INITIALIZE_APP, handleInitializeApp)
+  
+  // 앱 로드 (일반 실행)
+  ipcMain.handle(CHANNELS.LOAD_APP, handleLoadApp)
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron'
 import treeHandlers from './tree.js'
 import favoriteHandlers from './favorite.js'
+import registerAppHandlers from './app.js'
 
+registerAppHandlers()
 treeHandlers(ipcMain)
 favoriteHandlers(ipcMain)

--- a/apps/desktop/src/main/models/app/const.ts
+++ b/apps/desktop/src/main/models/app/const.ts
@@ -1,0 +1,10 @@
+/**
+ * 앱 레벨 경로 상수 (캡슐화됨)
+ * 외부에서 직접 접근 불가, 경로 함수를 통해서만 사용
+ */
+const APP_PATHS = {
+  CONFIG_FILE: 'config.json', // 앱 설정 (workspacePath 포함)
+  CACHE_FILE: 'cache.db', // SQLite 캐시 (기존 database.sqlite에서 변경)
+} as const
+
+export { APP_PATHS }

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import fs from 'fs-extra'
+import { app } from 'electron'
+import { getConfigPath, getCachePath, isInitialized, loadAppConfig } from './index.js'
+
+// Electron app mock
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((key) => {
+      if (key === 'userData') return '/mock/userData'
+      if (key === 'cache') return '/mock/cache'
+      return '/mock/path'
+    }),
+  },
+}))
+
+vi.mock('fs-extra')
+
+describe('App Model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getConfigPath', () => {
+    it('should return correct config path', () => {
+      const path = getConfigPath()
+      expect(path).toBe('/mock/userData/config.json')
+      expect(app.getPath).toHaveBeenCalledWith('userData')
+    })
+  })
+
+  describe('getCachePath', () => {
+    it('should return correct cache path', () => {
+      const path = getCachePath()
+      expect(path).toBe('/mock/userData/cache.db')
+      expect(app.getPath).toHaveBeenCalledWith('userData')
+    })
+  })
+
+  describe('isInitialized', () => {
+    it('should return true when config exists', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+
+      const result = await isInitialized()
+
+      expect(result).toBe(true)
+      expect(fs.existsSync).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+
+    it('should return false when config does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      const result = await isInitialized()
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('loadAppConfig', () => {
+    it('should load config when file exists', async () => {
+      const mockConfig = { workspacePath: '/test/workspace' }
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
+
+      const config = await loadAppConfig()
+
+      expect(config).toEqual(mockConfig)
+      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+
+    it('should throw error when config file does not exist', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      await expect(loadAppConfig()).rejects.toThrow(
+        'App configuration not found. Initialization required.',
+      )
+    })
+
+    it('should throw error when workspacePath is missing', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.readJson).mockResolvedValue({})
+
+      await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')
+    })
+  })
+})

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,6 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { tmpdir } from 'os'
-import { join } from 'path'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import fs from 'fs-extra'
 import { app } from 'electron'
 import { 
@@ -10,8 +8,7 @@ import {
   loadAppConfig,
   getAppConfig,
   setAppConfig,
-  initializeApp,
-  loadApp
+  initializeApp
 } from './index.js'
 
 // Electron app mock

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,7 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import fs from 'fs-extra'
 import { app } from 'electron'
-import { getConfigPath, getCachePath, isInitialized, loadAppConfig } from './index.js'
+import { 
+  getConfigPath, 
+  getCachePath, 
+  isInitialized, 
+  loadAppConfig,
+  getAppConfig,
+  setAppConfig,
+  initializeApp,
+  loadApp
+} from './index.js'
 
 // Electron app mock
 vi.mock('electron', () => ({
@@ -15,10 +26,14 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('fs-extra')
+vi.mock('./workspace/index.js', () => ({
+  initializeWorkspace: vi.fn().mockResolvedValue(undefined)
+}))
 
 describe('App Model', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    setAppConfig(null)
   })
 
   describe('getConfigPath', () => {
@@ -57,7 +72,7 @@ describe('App Model', () => {
   })
 
   describe('loadAppConfig', () => {
-    it('should load config when file exists', async () => {
+    it('should load config when file exists and store in memory', async () => {
       const mockConfig = { workspacePath: '/test/workspace' }
       vi.mocked(fs.existsSync).mockReturnValue(true)
       vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
@@ -66,6 +81,7 @@ describe('App Model', () => {
 
       expect(config).toEqual(mockConfig)
       expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+      expect(getAppConfig()).toEqual(mockConfig)
     })
 
     it('should throw error when config file does not exist', async () => {
@@ -81,6 +97,42 @@ describe('App Model', () => {
       vi.mocked(fs.readJson).mockResolvedValue({})
 
       await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')
+    })
+  })
+
+  describe('initializeApp', () => {
+    it('should initialize app with workspace path', async () => {
+      const mockWorkspacePath = '/test/workspace'
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+
+      await initializeApp({ workspacePath: mockWorkspacePath })
+
+      // 설정 파일이 저장되었는지 확인
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        '/mock/userData/config.json',
+        expect.objectContaining({
+          version: '1.0.0',
+          workspacePath: mockWorkspacePath,
+          createdAt: expect.any(String),
+          lastUsed: expect.any(String),
+        }),
+        { spaces: 2 }
+      )
+
+      // 워크스페이스 초기화가 호출되었는지 확인
+      const { initializeWorkspace } = await import('./workspace/index.js')
+      expect(initializeWorkspace).toHaveBeenCalledWith({ workspacePath: mockWorkspacePath })
+    })
+  })
+
+  describe('memory management', () => {
+    it('should manage app config in memory', () => {
+      expect(getAppConfig()).toBeNull()
+      
+      const testConfig = { workspacePath: '/test/path' }
+      setAppConfig(testConfig)
+      
+      expect(getAppConfig()).toEqual(testConfig)
     })
   })
 })

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -1,0 +1,43 @@
+import { app } from 'electron'
+import { join } from 'path'
+import fs from 'fs-extra'
+import { APP_PATHS } from './const.js'
+
+/**
+ * 앱 설정 파일 경로
+ * @returns ~/Library/Application Support/voyl/config.json
+ */
+export function getConfigPath(): string {
+  return join(app.getPath('userData'), APP_PATHS.CONFIG_FILE)
+}
+
+/**
+ * SQLite 캐시 데이터베이스 경로
+ * @returns ~/Library/Caches/voyl/cache.db (캐시 전용 디렉터리)
+ */
+export function getCachePath(): string {
+  return join(app.getPath('userData'), APP_PATHS.CACHE_FILE)
+}
+
+/**
+ * 앱 초기화 상태 확인
+ * 비동기로 통일하여 일관성 유지
+ */
+export async function isInitialized(): Promise<boolean> {
+  return fs.existsSync(getConfigPath())
+}
+
+/**
+ * 앱 설정 로드
+ */
+export async function loadAppConfig(): Promise<{ workspacePath: string }> {
+  const configPath = getConfigPath()
+  if (!fs.existsSync(configPath)) {
+    throw new Error('App configuration not found. Initialization required.')
+  }
+  const config = await fs.readJson(configPath)
+  if (!config.workspacePath) {
+    throw new Error('Workspace path not configured.')
+  }
+  return config
+}

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -92,9 +92,9 @@ export async function initializeApp({ workspacePath }: { workspacePath: string }
 export async function loadApp(): Promise<void> {
   // 1. config 파일에서 메모리로 로드 (이미 메모리에 있다면 파일에서 다시 로드)
   await loadAppConfig()
-  // 2. 캐시 DB 초기화는 별도로 구현 예정
-  // const cachePath = getCachePath()
-  // await initializeDB(cachePath)
+  // 2. DB 초기화
+  const { initializeDatabase } = await import('../../db/connect.js')
+  initializeDatabase()
 }
 
 /**

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { join } from 'path'
 import fs from 'fs-extra'
 import { APP_PATHS } from './const.js'
+import { initializeWorkspace } from './workspace/index.js'
 
 /**
  * 앱 설정 파일 경로
@@ -27,8 +28,25 @@ export async function isInitialized(): Promise<boolean> {
   return fs.existsSync(getConfigPath())
 }
 
+// 앱 설정 싱글톤 메모리 관리
+let appConfig: { workspacePath: string } | null = null
+
 /**
- * 앱 설정 로드
+ * 메모리에서 앱 설정 조회 (싱글톤)
+ */
+export function getAppConfig(): { workspacePath: string } | null {
+  return appConfig
+}
+
+/**
+ * 메모리에 앱 설정 저장 (싱글톤)
+ */
+export function setAppConfig(config: { workspacePath: string } | null): void {
+  appConfig = config
+}
+
+/**
+ * 파일에서 앱 설정 로드하여 메모리에 저장
  */
 export async function loadAppConfig(): Promise<{ workspacePath: string }> {
   const configPath = getConfigPath()
@@ -39,5 +57,57 @@ export async function loadAppConfig(): Promise<{ workspacePath: string }> {
   if (!config.workspacePath) {
     throw new Error('Workspace path not configured.')
   }
+  setAppConfig(config)
   return config
+}
+
+/**
+ * 앱 설정 기반 워크스페이스 초기화 (IPC에서 호출)
+ * @returns 초기화된 워크스페이스 경로
+ */
+export async function initializeFromConfig(): Promise<string> {
+  const config = await loadAppConfig()
+
+  // 워크스페이스 초기화 (경로 검사 + 디렉터리 생성 + 설정)
+  await initializeWorkspace({ workspacePath: config.workspacePath })
+
+  return config.workspacePath
+}
+
+/**
+ * 앱 초기화 (첫 실행 - 설정 생성만)
+ * @param workspacePath 사용자가 선택한 경로
+ */
+export async function initializeApp({ workspacePath }: { workspacePath: string }): Promise<void> {
+  // 1. 앱 설정을 파일에 저장
+  await saveAppConfigToFile({ workspacePath })
+  // 2. 워크스페이스 초기화 (폴더 구조 생성 + 권한 확인)
+  await initializeWorkspace({ workspacePath })
+  // 초기화 완료: DB 초기화는 loadApp()에서 별도로 수행
+}
+
+/**
+ * 앱 로드 (설정 로드 + DB 초기화)
+ */
+export async function loadApp(): Promise<void> {
+  // 1. config 파일에서 메모리로 로드 (이미 메모리에 있다면 파일에서 다시 로드)
+  await loadAppConfig()
+  // 2. 캐시 DB 초기화는 별도로 구현 예정
+  // const cachePath = getCachePath()
+  // await initializeDB(cachePath)
+}
+
+/**
+ * 앱 설정을 파일에 저장
+ */
+async function saveAppConfigToFile(config: { workspacePath: string }): Promise<void> {
+  const configPath = getConfigPath()
+  const fullConfig = {
+    version: '1.0.0',
+    workspacePath: config.workspacePath,
+    createdAt: new Date().toISOString(),
+    lastUsed: new Date().toISOString(),
+  }
+
+  await fs.writeJson(configPath, fullConfig, { spaces: 2 })
 }

--- a/apps/desktop/src/main/models/app/workspace/const.ts
+++ b/apps/desktop/src/main/models/app/workspace/const.ts
@@ -1,0 +1,12 @@
+/**
+ * 워크스페이스 레벨 경로 상수 (캡슐화됨)
+ * 외부에서 직접 접근 불가, 경로 함수를 통해서만 사용
+ */
+const WORKSPACE_PATHS = {
+  SETTINGS_FILE: 'settings.json', // 워크스페이스 설정
+  NODES_DIR: 'nodes', // 노드 메타데이터 (향후)
+  CONTENT_DIR: 'content', // 긴 본문 파일 (향후)
+  LOG_DIR: 'log', // 변경 이력 (향후)
+} as const
+
+export { WORKSPACE_PATHS }

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import fs from 'fs-extra'
+import { 
+  getWorkspacePath, 
+  getWorkspaceSettingsPath, 
+  getNodesPath,
+  getContentPath,
+  getLogPath
+} from './index.js'
+
+// Mock electron and fs-extra
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/mock/userData')
+  }
+}))
+
+vi.mock('fs-extra')
+
+describe('Workspace Model', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readJson).mockResolvedValue({
+      workspacePath: '/test/workspace'
+    })
+  })
+
+  describe('getWorkspacePath', () => {
+    it('should return workspace path from app config', async () => {
+      const path = await getWorkspacePath()
+      expect(path).toBe('/test/workspace')
+      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
+    })
+  })
+
+  describe('getWorkspaceSettingsPath', () => {
+    it('should return correct settings path', async () => {
+      const path = await getWorkspaceSettingsPath()
+      expect(path).toBe('/test/workspace/settings.json')
+    })
+  })
+
+  describe('getNodesPath', () => {
+    it('should return correct nodes path', async () => {
+      const path = await getNodesPath()
+      expect(path).toBe('/test/workspace/nodes')
+    })
+  })
+
+  describe('getContentPath', () => {
+    it('should return correct content path', async () => {
+      const path = await getContentPath()
+      expect(path).toBe('/test/workspace/content')
+    })
+  })
+
+  describe('getLogPath', () => {
+    it('should return correct log path', async () => {
+      const path = await getLogPath()
+      expect(path).toBe('/test/workspace/log')
+    })
+  })
+})

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import fs from 'fs-extra'
 import { 
   getWorkspacePath, 
   getWorkspaceSettingsPath, 
   getNodesPath,
   getContentPath,
-  getLogPath
+  getLogPath,
+  initializeWorkspace,
+  checkWorkspacePermissions
 } from './index.js'
 
 // Mock electron and fs-extra
@@ -18,12 +22,19 @@ vi.mock('electron', () => ({
 vi.mock('fs-extra')
 
 describe('Workspace Model', () => {
+  const testWorkspacePath = join(tmpdir(), 'test-workspace-' + Date.now())
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(fs.existsSync).mockReturnValue(true)
     vi.mocked(fs.readJson).mockResolvedValue({
       workspacePath: '/test/workspace'
     })
+  })
+
+  afterEach(() => {
+    // Mock cleanup
+    vi.clearAllMocks()
   })
 
   describe('getWorkspacePath', () => {
@@ -59,6 +70,89 @@ describe('Workspace Model', () => {
     it('should return correct log path', async () => {
       const path = await getLogPath()
       expect(path).toBe('/test/workspace/log')
+    })
+  })
+
+  describe('initializeWorkspace', () => {
+    beforeEach(() => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+      vi.mocked(fs.pathExists).mockResolvedValue(false)
+      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+    })
+
+    it('should create all required directories', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      // 디렉터리 생성 확인
+      expect(fs.ensureDir).toHaveBeenCalledWith(testWorkspacePath)
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'nodes'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'content'))
+      expect(fs.ensureDir).toHaveBeenCalledWith(join(testWorkspacePath, 'log'))
+    })
+
+    it('should create settings.json with default values', async () => {
+      await initializeWorkspace({ workspacePath: testWorkspacePath })
+
+      expect(fs.writeJson).toHaveBeenCalledWith(
+        join(testWorkspacePath, 'settings.json'),
+        expect.objectContaining({
+          version: '1.0.0',
+          createdAt: expect.any(String),
+          nodeTypes: [],
+          attributes: []
+        }),
+        { spaces: 2 }
+      )
+    })
+
+    it('should validate workspace path', async () => {
+      await expect(initializeWorkspace({ workspacePath: '' })).rejects.toThrow(
+        'Workspace path cannot be empty'
+      )
+
+      await expect(initializeWorkspace({ workspacePath: 'relative/path' })).rejects.toThrow(
+        'Workspace path must be absolute'
+      )
+    })
+
+    it('should cleanup on failure', async () => {
+      // Mock ensureDir to fail on second call
+      vi.mocked(fs.ensureDir)
+        .mockResolvedValueOnce(undefined) // workspace dir succeeds
+        .mockRejectedValueOnce(new Error('Permission denied')) // nodes dir fails
+
+      await expect(initializeWorkspace({ workspacePath: testWorkspacePath })).rejects.toThrow()
+
+      // Verify cleanup was attempted
+      expect(fs.remove).toHaveBeenCalled()
+    })
+  })
+
+  describe('checkWorkspacePermissions', () => {
+    it('should check read/write permissions', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockResolvedValue(undefined)
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined)
+      vi.mocked(fs.remove).mockResolvedValue(undefined)
+
+      await checkWorkspacePermissions({ workspacePath: testWorkspacePath })
+
+      expect(fs.access).toHaveBeenCalledWith(
+        testWorkspacePath,
+        fs.constants.R_OK | fs.constants.W_OK
+      )
+    })
+
+    it('should throw on insufficient permissions', async () => {
+      vi.mocked(fs.ensureDir).mockResolvedValue(undefined)
+      vi.mocked(fs.access).mockRejectedValue(new Error('Permission denied'))
+
+      await expect(checkWorkspacePermissions({ workspacePath: testWorkspacePath })).rejects.toThrow(
+        `Insufficient permissions for workspace: ${testWorkspacePath}`
+      )
     })
   })
 })

--- a/apps/desktop/src/main/models/app/workspace/index.test.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.test.ts
@@ -79,7 +79,7 @@ describe('Workspace Model', () => {
       vi.mocked(fs.access).mockResolvedValue(undefined)
       vi.mocked(fs.writeFile).mockResolvedValue(undefined)
       vi.mocked(fs.remove).mockResolvedValue(undefined)
-      vi.mocked(fs.pathExists).mockResolvedValue(false)
+      vi.mocked(fs.pathExists).mockResolvedValue(false as any)
       vi.mocked(fs.writeJson).mockResolvedValue(undefined)
     })
 

--- a/apps/desktop/src/main/models/app/workspace/index.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.ts
@@ -1,0 +1,64 @@
+import { join } from 'path'
+import fs from 'fs-extra'
+import { app } from 'electron'
+import { WORKSPACE_PATHS } from './const.js'
+
+/**
+ * 워크스페이스 설정 조회를 위한 내부 헬퍼
+ */
+async function getWorkspaceConfig(): Promise<{ workspacePath: string }> {
+  const configPath = join(app.getPath('userData'), 'config.json')
+  if (!fs.existsSync(configPath)) {
+    throw new Error('App configuration not found. Initialization required.')
+  }
+  const config = await fs.readJson(configPath)
+  if (!config.workspacePath) {
+    throw new Error('Workspace path not configured.')
+  }
+  return config
+}
+
+/**
+ * 사용자 워크스페이스 루트 경로
+ * 앱 설정에서 로드
+ */
+export async function getWorkspacePath(): Promise<string> {
+  const config = await getWorkspaceConfig()
+  return config.workspacePath
+}
+
+/**
+ * 워크스페이스 설정 파일 경로
+ * @returns [workspace]/settings.json
+ */
+export async function getWorkspaceSettingsPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE)
+}
+
+/**
+ * 노드 메타데이터 디렉터리 경로
+ * @returns [workspace]/nodes
+ */
+export async function getNodesPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.NODES_DIR)
+}
+
+/**
+ * 콘텐츠 파일 디렉터리 경로
+ * @returns [workspace]/content
+ */
+export async function getContentPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR)
+}
+
+/**
+ * 로그 파일 디렉터리 경로
+ * @returns [workspace]/log
+ */
+export async function getLogPath(): Promise<string> {
+  const workspacePath = await getWorkspacePath()
+  return join(workspacePath, WORKSPACE_PATHS.LOG_DIR)
+}

--- a/apps/desktop/src/main/models/app/workspace/index.ts
+++ b/apps/desktop/src/main/models/app/workspace/index.ts
@@ -1,4 +1,5 @@
 import { join } from 'path'
+import path from 'path'
 import fs from 'fs-extra'
 import { app } from 'electron'
 import { WORKSPACE_PATHS } from './const.js'
@@ -61,4 +62,138 @@ export async function getContentPath(): Promise<string> {
 export async function getLogPath(): Promise<string> {
   const workspacePath = await getWorkspacePath()
   return join(workspacePath, WORKSPACE_PATHS.LOG_DIR)
+}
+
+/**
+ * 워크스페이스 권한 확인
+ */
+export async function checkWorkspacePermissions({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  try {
+    // 1. 경로 존재 확인 및 생성
+    await fs.ensureDir(workspacePath)
+
+    // 2. 읽기/쓰기 권한 확인
+    await fs.access(workspacePath, fs.constants.R_OK | fs.constants.W_OK)
+
+    // 3. 실제 쓰기 테스트
+    const testFile = join(workspacePath, '.test-write-permission')
+    await fs.writeFile(testFile, 'test')
+    await fs.remove(testFile)
+  } catch (error) {
+    throw new Error(`Insufficient permissions for workspace: ${workspacePath}`)
+  }
+}
+
+/**
+ * 워크스페이스 전체 초기화 조정자
+ * 최소 초기화: 필수 디렉터리 확인/생성
+ * 실패 시 자동 정리 수행
+ */
+export async function initializeWorkspace({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  try {
+    // 순차적 초기화 (의존성 고려)
+    await validateWorkspacePath({ workspacePath })
+    await checkWorkspacePermissions({ workspacePath })
+    await initDirectories({ workspacePath }) // 최소 초기화: 필수 디렉터리
+    await initSettings({ workspacePath }) // 최소 초기화: 기본 설정 파일
+  } catch (error) {
+    // 초기화 실패 시 정리
+    await cleanupFailedInitialization({ workspacePath })
+    throw error
+  }
+}
+
+/**
+ * 워크스페이스 경로 검증 (권한 체크는 별도 함수에서 수행)
+ */
+async function validateWorkspacePath({ workspacePath }: { workspacePath: string }): Promise<void> {
+  // 기본적인 경로 유효성 검증
+  if (!workspacePath || workspacePath.trim() === '') {
+    throw new Error('Workspace path cannot be empty')
+  }
+
+  // 절대 경로 확인
+  if (!path.isAbsolute(workspacePath)) {
+    throw new Error('Workspace path must be absolute')
+  }
+}
+
+/**
+ * 워크스페이스 내 필요한 디렉터리들을 병렬 생성
+ */
+async function initDirectories({ workspacePath }: { workspacePath: string }): Promise<void> {
+  const directories = [
+    join(workspacePath, WORKSPACE_PATHS.NODES_DIR),
+    join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR),
+    join(workspacePath, WORKSPACE_PATHS.LOG_DIR),
+  ]
+
+  // 병렬 생성으로 성능 최적화
+  await Promise.all(directories.map((dir) => fs.ensureDir(dir)))
+}
+
+/**
+ * 워크스페이스 설정 파일 생성/검증
+ */
+async function initSettings({ workspacePath }: { workspacePath: string }): Promise<void> {
+  const settingsPath = join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE)
+
+  if (!(await fs.pathExists(settingsPath))) {
+    const defaultSettings = createDefaultSettings()
+    await fs.writeJson(settingsPath, defaultSettings, { spaces: 2 })
+  }
+}
+
+/**
+ * 기본 워크스페이스 설정 생성
+ */
+function createDefaultSettings() {
+  return {
+    version: '1.0.0',
+    createdAt: new Date().toISOString(),
+    nodeTypes: [], // Node type definitions (빈 배열로 시작)
+    attributes: [], // Attribute definitions (빈 배열로 시작)
+    // 향후 확장: 테마, 언어, 플러그인 등
+  }
+}
+
+/**
+ * 실패한 초기화 정리 - 생성된 모든 항목 강제 삭제
+ */
+async function cleanupFailedInitialization({
+  workspacePath,
+}: {
+  workspacePath: string
+}): Promise<void> {
+  const itemsToCleanup = [
+    // 파일들
+    join(workspacePath, WORKSPACE_PATHS.SETTINGS_FILE),
+
+    // 디렉터리들
+    join(workspacePath, WORKSPACE_PATHS.NODES_DIR),
+    join(workspacePath, WORKSPACE_PATHS.CONTENT_DIR),
+    join(workspacePath, WORKSPACE_PATHS.LOG_DIR),
+  ]
+
+  // 모든 항목 삭제 시도 (존재하지 않아도 에러 안남)
+  await Promise.allSettled(itemsToCleanup.map((item) => fs.remove(item)))
+
+  // 워크스페이스 폴더가 비어있다면 삭제
+  try {
+    const files = await fs.readdir(workspacePath)
+    if (files.length === 0) {
+      await fs.remove(workspacePath)
+    }
+  } catch {
+    // 삭제 실패해도 무시
+    console.warn('Failed to cleanup incomplete workspace initialization')
+  }
 }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -1,8 +1,15 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
 
+interface IElectronAPI {
+  isInitialized(): Promise<boolean>
+  selectWorkspacePath(): Promise<string | null>
+  initializeApp(path: string): Promise<void>
+  loadApp(): Promise<void>
+}
+
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: unknown
+    api: IElectronAPI
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,8 +1,14 @@
-import { contextBridge } from 'electron'
+import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
+import { CHANNELS } from '../common/channel.const.js'
 
 // Custom APIs for renderer
-const api = {}
+const api = {
+  isInitialized: () => ipcRenderer.invoke(CHANNELS.IS_INITIALIZED),
+  selectWorkspacePath: () => ipcRenderer.invoke(CHANNELS.SELECT_WORKSPACE_PATH),
+  initializeApp: (path: string) => ipcRenderer.invoke(CHANNELS.INITIALIZE_APP, path),
+  loadApp: () => ipcRenderer.invoke(CHANNELS.LOAD_APP),
+}
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise

--- a/apps/desktop/src/renderer/common/Alert.tsx
+++ b/apps/desktop/src/renderer/common/Alert.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import cn from './shared/cn.js'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertTitle, AlertDescription }

--- a/apps/desktop/src/renderer/common/Button.tsx
+++ b/apps/desktop/src/renderer/common/Button.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import cn from './shared/cn.js'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button'
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/apps/desktop/src/renderer/common/Dialog.tsx
+++ b/apps/desktop/src/renderer/common/Dialog.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import cn from './shared/cn.js'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/apps/desktop/src/renderer/pages/AppGuard.tsx
+++ b/apps/desktop/src/renderer/pages/AppGuard.tsx
@@ -1,0 +1,11 @@
+import { useAppInitialized } from '@/renderer/store/app/index.js'
+import StorageLocationDialog from './StorageLocationDialog.js'
+
+export default function AppGuard() {
+  const { isInitialized } = useAppInitialized()
+
+  // 이미 초기화되었으면 아무것도 표시하지 않음
+  if (isInitialized) return null
+
+  return <StorageLocationDialog />
+}

--- a/apps/desktop/src/renderer/pages/ErrorMessage.tsx
+++ b/apps/desktop/src/renderer/pages/ErrorMessage.tsx
@@ -1,0 +1,17 @@
+import { Alert, AlertDescription } from '@/renderer/common/Alert.js'
+
+interface ErrorMessageProps {
+  error: unknown
+}
+
+export default function ErrorMessage({ error }: ErrorMessageProps) {
+  if (!error) return null
+  
+  const message = error instanceof Error ? error.message : '오류가 발생했습니다'
+  
+  return (
+    <Alert variant="destructive">
+      <AlertDescription>{message}</AlertDescription>
+    </Alert>
+  )
+}

--- a/apps/desktop/src/renderer/pages/InitializingView.tsx
+++ b/apps/desktop/src/renderer/pages/InitializingView.tsx
@@ -1,0 +1,18 @@
+import { Loader2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+} from '@/renderer/common/Dialog.js'
+
+export default function InitializingView() {
+  return (
+    <Dialog open={true}>
+      <DialogContent className="sm:max-w-[500px]">
+        <div className="flex flex-col items-center justify-center py-8 space-y-4">
+          <Loader2 className="h-10 w-10 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">워크스페이스를 설정하고 있습니다...</p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/pages/StorageLocationDialog.tsx
+++ b/apps/desktop/src/renderer/pages/StorageLocationDialog.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { useInitializeWorkspace } from '@/renderer/store/app/index.js'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/renderer/common/Dialog.js'
+import { Button } from '@/renderer/common/Button.js'
+import InitializingView from './InitializingView.js'
+import WorkspacePathSelector from './WorkspacePathSelector.js'
+import ErrorMessage from './ErrorMessage.js'
+
+export default function StorageLocationDialog() {
+  const [selectedPath, setSelectedPath] = useState('')
+  const initialize = useInitializeWorkspace()
+
+  const handleInitialize = () => {
+    if (!selectedPath) return
+    initialize.mutate(selectedPath)
+  }
+
+  if (initialize.isPending) {
+    return <InitializingView />
+  }
+
+  return (
+    <Dialog open={true}>
+      <DialogContent 
+        className="sm:max-w-[500px]" 
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Voyl 워크스페이스 설정</DialogTitle>
+          <DialogDescription>
+            데이터를 저장할 폴더를 선택해주세요. 
+            Google Drive나 Dropbox 폴더를 선택하면 여러 기기에서 동기화할 수 있습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <WorkspacePathSelector 
+            selectedPath={selectedPath}
+            onPathSelect={setSelectedPath}
+          />
+          
+          <ErrorMessage error={initialize.error} />
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={handleInitialize}
+            disabled={!selectedPath}
+          >
+            워크스페이스 생성
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/pages/WorkspacePathSelector.tsx
+++ b/apps/desktop/src/renderer/pages/WorkspacePathSelector.tsx
@@ -1,0 +1,61 @@
+import { FolderIcon, Loader2 } from 'lucide-react'
+import { useSelectWorkspacePath } from '@/renderer/store/app/index.js'
+import { Button } from '@/renderer/common/Button.js'
+import { Alert, AlertDescription } from '@/renderer/common/Alert.js'
+
+interface WorkspacePathSelectorProps {
+  selectedPath: string
+  onPathSelect: (path: string) => void
+}
+
+export default function WorkspacePathSelector({ 
+  selectedPath, 
+  onPathSelect 
+}: WorkspacePathSelectorProps) {
+  const selectPath = useSelectWorkspacePath()
+
+  const handleSelectPath = () => {
+    selectPath.mutate(undefined, {
+      onSuccess: (path) => {
+        if (path) onPathSelect(path)
+      }
+    })
+  }
+
+  return (
+    <>
+      <div className="flex justify-center">
+        <Button
+          variant="outline"
+          size="lg"
+          onClick={handleSelectPath}
+          disabled={selectPath.isPending}
+          className="w-full max-w-sm"
+        >
+          {selectPath.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <FolderIcon className="mr-2 h-4 w-4" />
+          )}
+          저장 위치 선택
+        </Button>
+      </div>
+
+      {selectedPath && (
+        <Alert>
+          <AlertDescription>
+            <strong>선택된 경로:</strong> {selectedPath}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {selectPath.error && (
+        <Alert variant="destructive">
+          <AlertDescription>
+            {selectPath.error instanceof Error ? selectPath.error.message : '경로 선택 중 오류가 발생했습니다'}
+          </AlertDescription>
+        </Alert>
+      )}
+    </>
+  )
+}

--- a/apps/desktop/src/renderer/pages/index.tsx
+++ b/apps/desktop/src/renderer/pages/index.tsx
@@ -1,20 +1,29 @@
+import { Suspense } from 'react'
 import NodesPage from './nodes'
 import TopBar from './TopBar'
 import SideBar from './SideBar'
 import { Route, Routes } from 'react-router'
+import AppGuard from './AppGuard.js'
 
 export default function IndexPage() {
   return (
-    <div className="flex h-screen flex-col gap-0">
-      <TopBar />
-      <div className="flex w-full flex-1 flex-row gap-0">
-        <SideBar />
-        <Routes>
-          <Route path="nodes" element={<NodesPage />} />
-          <Route path="nodes/:nodeId" element={<NodesPage />} />
-          <Route path="*" element={<NodesPage />} />
-        </Routes>
+    <>
+      <div className="flex h-screen flex-col gap-0">
+        <TopBar />
+        <div className="flex w-full flex-1 flex-row gap-0">
+          <SideBar />
+          <Routes>
+            <Route path="nodes" element={<NodesPage />} />
+            <Route path="nodes/:nodeId" element={<NodesPage />} />
+            <Route path="*" element={<NodesPage />} />
+          </Routes>
+        </div>
       </div>
-    </div>
+
+      {/* 앱 초기화 확인 */}
+      <Suspense fallback={null}>
+        <AppGuard />
+      </Suspense>
+    </>
   )
 }

--- a/apps/desktop/src/renderer/repos/app.ts
+++ b/apps/desktop/src/renderer/repos/app.ts
@@ -1,0 +1,47 @@
+/**
+ * 앱 초기화 상태 확인
+ */
+export async function isInitialized(): Promise<boolean> {
+  try {
+    return await window.api.isInitialized()
+  } catch (error) {
+    console.error('Failed to check initialization status:', error)
+    return false
+  }
+}
+
+/**
+ * 워크스페이스 경로 선택 (Documents 초기 경로)
+ */
+export async function selectWorkspacePath(): Promise<string | null> {
+  try {
+    return await window.api.selectWorkspacePath()
+  } catch (error) {
+    console.error('Failed to open directory dialog:', error)
+    return null
+  }
+}
+
+/**
+ * 앱 초기화 (설정 생성 + 워크스페이스 폴더 생성)
+ */
+export async function initializeApp(path: string): Promise<void> {
+  try {
+    await window.api.initializeApp(path)
+  } catch (error) {
+    console.error('Failed to initialize app:', error)
+    throw new Error((error as Error).message || 'Failed to initialize app')
+  }
+}
+
+/**
+ * 앱 로드 (DB 초기화 등)
+ */
+export async function loadApp(): Promise<void> {
+  try {
+    await window.api.loadApp()
+  } catch (error) {
+    console.error('Failed to load app:', error)
+    throw new Error((error as Error).message || 'Failed to load app')
+  }
+}

--- a/apps/desktop/src/renderer/store/app/const.ts
+++ b/apps/desktop/src/renderer/store/app/const.ts
@@ -1,0 +1,6 @@
+export const QUERY_KEYS = {
+  all: ['app'] as const,
+  initialization: () => [...QUERY_KEYS.all, 'initialization'] as const,
+  config: () => [...QUERY_KEYS.all, 'config'] as const,
+  workspace: () => [...QUERY_KEYS.all, 'workspace'] as const,
+}

--- a/apps/desktop/src/renderer/store/app/index.ts
+++ b/apps/desktop/src/renderer/store/app/index.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
+import { selectWorkspacePath, initializeApp, loadApp } from '@/renderer/repos/app.js'
+import { QUERY_KEYS } from './const.js'
+import { getInitializationQueryOptions } from './queryOptions.js'
+
+/**
+ * 앱 초기화 상태 Hook
+ */
+export function useAppInitialized() {
+  const { data: isInitialized } = useSuspenseQuery(getInitializationQueryOptions())
+  
+  return { 
+    isInitialized: isInitialized ?? false
+  }
+}
+
+/**
+ * 워크스페이스 경로 선택 mutation
+ */
+export function useSelectWorkspacePath() {
+  return useMutation({
+    mutationFn: selectWorkspacePath,
+  })
+}
+
+/**
+ * 워크스페이스 초기화 mutation
+ */
+export function useInitializeWorkspace() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: async (path: string) => {
+      // 1. 초기화 (설정 생성 + 워크스페이스 폴더 생성)
+      await initializeApp(path)
+      // 2. 로드 (DB 초기화 등)
+      await loadApp()
+      return true
+    },
+    onSuccess: () => {
+      // 초기화 성공 시 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.initialization() })
+    },
+  })
+}

--- a/apps/desktop/src/renderer/store/app/queryOptions.ts
+++ b/apps/desktop/src/renderer/store/app/queryOptions.ts
@@ -1,0 +1,10 @@
+import { isInitialized } from '@/renderer/repos/app.js'
+import { QUERY_KEYS } from './const.js'
+
+export const getInitializationQueryOptions = () => ({
+  queryKey: QUERY_KEYS.initialization(),
+  queryFn: isInitialized,
+  retry: false,
+  staleTime: Infinity,
+  gcTime: Infinity,
+})

--- a/docs/planning/20250720-infrastructure-layer/INTEGRATION.md
+++ b/docs/planning/20250720-infrastructure-layer/INTEGRATION.md
@@ -1,0 +1,60 @@
+# 앱 시작 통합 완료
+
+## 구현 완료 사항
+
+### 1. DB 지연 초기화
+- `db/connect.ts`를 지연 초기화 패턴으로 변경
+- `initializeDatabase()`: DB 연결 초기화
+- `getDatabase()`: DB 인스턴스 반환
+- `closeDatabase()`: DB 연결 종료
+
+### 2. 앱 시작 플로우
+- main/index.ts에서 db/connect.js import 제거
+- DB는 loadApp() 호출 시점에 초기화
+- 앱 종료 시 DB 연결 정리
+
+### 3. 전체 플로우
+
+#### 첫 실행
+1. 앱 시작 → IPC 핸들러 등록
+2. 프론트엔드 → `isInitialized()` → false
+3. `StorageLocationDialog` 표시
+4. 경로 선택 → `initializeApp(path)`
+5. 워크스페이스 생성
+6. `loadApp()` → DB 초기화
+7. 메인 화면 진입
+
+#### 기존 사용자
+1. 앱 시작 → IPC 핸들러 등록
+2. 프론트엔드 → `isInitialized()` → true
+3. `loadApp()` → DB 초기화
+4. 메인 화면 진입
+
+## 파일 변경 사항
+
+### 수정된 파일
+- `src/main/index.ts`: DB import 제거, 종료 시 정리
+- `src/main/db/connect.ts`: 지연 초기화 패턴
+- `src/main/models/app/index.ts`: loadApp에서 DB 초기화
+
+### 추가된 파일
+- 모든 UI 컴포넌트 (PR 4)
+- IPC 핸들러 (PR 3)
+- 워크스페이스 초기화 (PR 2)
+- 경로 관리 유틸리티 (PR 1)
+
+## 테스트 방법
+
+1. 기존 config 파일 삭제
+```bash
+rm ~/Library/Application\ Support/voyl/config.json
+```
+
+2. 앱 실행
+```bash
+pnpm dev
+```
+
+3. 워크스페이스 선택 다이얼로그 확인
+4. 경로 선택 후 초기화 확인
+5. 앱 재시작 시 바로 메인 화면 진입 확인

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@fontsource/roboto-mono':
         specifier: ^5.2.6
         version: 5.2.6
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -851,6 +854,9 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -895,6 +901,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -906,6 +925,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.10':
     resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -932,6 +964,15 @@ packages:
 
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1015,6 +1056,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.4':
     resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5381,6 +5435,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -5414,6 +5470,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      aria-hidden: 1.2.5
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.0(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -5423,6 +5501,19 @@ snapshots:
   '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
@@ -5449,6 +5540,12 @@ snapshots:
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-focus-guards@1.1.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
       react: 19.1.0
     optionalDependencies:
@@ -5550,6 +5647,16 @@ snapshots:
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       electron-updater:
         specifier: ^6.6.2
         version: 6.6.2
+      fs-extra:
+        specifier: ^11.2.0
+        version: 11.3.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -141,6 +144,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -1445,6 +1451,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -1456,6 +1465,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
@@ -5915,6 +5927,11 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 24.0.10
+
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 24.0.10
@@ -5924,6 +5941,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 24.0.10
 
   '@types/keyv@3.1.4':
     dependencies:


### PR DESCRIPTION
## 개요
인프라 레이어의 마지막 PR입니다. 모든 구성요소를 통합하여 완전한 앱 시작 프로세스를 구현합니다.

## 주요 변경사항

### 1. DB 지연 초기화
- **initializeDatabase()**: DB 연결을 필요 시점에 초기화
- **getDatabase()**: 초기화된 DB 인스턴스 반환
- **closeDatabase()**: 앱 종료 시 DB 연결 정리
- Proxy 패턴으로 기존 코드와 호환성 유지

### 2. 앱 시작 플로우 개선
- main/index.ts에서 자동 DB 연결 제거
- loadApp() 호출 시점에 DB 초기화
- 앱 종료 시 자원 정리 (before-quit 이벤트)

### 3. 전체 플로우

#### 첫 실행 시나리오
1. 앱 시작 → IPC 핸들러만 등록
2. 프론트엔드에서 초기화 상태 확인 → false
3. 워크스페이스 선택 다이얼로그 표시
4. 사용자 경로 선택 → initializeApp() 호출
5. 워크스페이스 구조 생성 및 설정 저장
6. loadApp() → DB 초기화
7. 메인 화면 진입

#### 기존 사용자 시나리오
1. 앱 시작 → IPC 핸들러만 등록
2. 프론트엔드에서 초기화 상태 확인 → true
3. loadApp() 호출 → DB 초기화
4. 메인 화면 바로 진입

## 의존성
- PR 1: 경로 관리 유틸리티
- PR 2: 워크스페이스 초기화
- PR 3: IPC 핸들러
- PR 4: 프론트엔드 UI

## 테스트 방법
```bash
# 1. 기존 설정 제거 (첫 실행 테스트)
rm ~/Library/Application\ Support/voyl/config.json

# 2. 앱 실행
pnpm dev

# 3. 워크스페이스 선택 및 초기화 확인
# 4. 앱 재시작 시 바로 메인 화면 진입 확인
```

## 체크리스트
- [x] DB 지연 초기화 구현
- [x] 앱 시작 플로우 통합
- [x] 자원 정리 로직 추가
- [x] 문서화 (INTEGRATION.md)

## 완료된 인프라 레이어
1. ✅ 경로 관리 유틸리티
2. ✅ 워크스페이스 초기화
3. ✅ IPC 핸들러
4. ✅ 프론트엔드 UI
5. ✅ 앱 시작 통합

모든 인프라 레이어 구현이 완료되었습니다! 🎉