### PR TITLE
feat: Repo 계층 구현 및 AppRepo 추가

### DIFF
--- a/apps/desktop/eslint.config.mjs
+++ b/apps/desktop/eslint.config.mjs
@@ -166,6 +166,7 @@ export default [
             '**/src/main/ipc/**',
             '**/src/main/models/**',
             '**/src/main/windows/**',
+            '**/src/main/repo/**',
           ],
           tsconfigPath: path.resolve(__dirname, './tsconfig.node.json'),
         },
@@ -198,6 +199,26 @@ export default [
         {
           patterns: [
             '**/src/main/db/**',
+            '**/src/main/common/*',
+            '**/src/main/common/shared/*',
+            '**/src/common/*',
+          ],
+          tsconfigPath: path.resolve(__dirname, './tsconfig.node.json'),
+        },
+      ],
+    },
+  },
+  {
+    files: ['src/main/repo/**/*.{ts,tsx}'],
+    plugins: {
+      voyl: voylPlugin,
+    },
+    rules: {
+      'voyl/restrict-imports-to-pattern': [
+        'error',
+        {
+          patterns: [
+            '**/src/main/repo/**',
             '**/src/main/common/*',
             '**/src/main/common/shared/*',
             '**/src/common/*',
@@ -243,6 +264,7 @@ export default [
             '**/src/main/common/*',
             '**/src/main/common/shared/*',
             '**/src/main/db/*/*',
+            '**/src/main/repo/*/*',
             '**/src/main/db/index.js',
             '**/src/common/*',
           ],

--- a/apps/desktop/src/common/channel.const.ts
+++ b/apps/desktop/src/common/channel.const.ts
@@ -3,8 +3,7 @@ export const CHANNELS = {
   IS_INITIALIZED: '/app/is-initialized',
   SELECT_WORKSPACE_PATH: '/app/workspace/select-path',
   INITIALIZE_APP: '/app/initialize',
-  LOAD_APP: '/app/load',
-  
+
   // Node channels
   GET_NODE_TABLE: '/nodes/table/get',
   GET_NODE: '/tree/node/get',

--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -96,10 +96,10 @@ async function createSchemaRuntime(): Promise<void> {
     // Drizzle 공식 migrate 함수 사용
     const { migrate } = await import('drizzle-orm/better-sqlite3/migrator')
     const { join } = await import('path')
-    
+
     // __dirname 대체 (ES modules)
     const migrationsPath = join(process.cwd(), 'src/main/db/migrations')
-    
+
     await migrate(db, {
       migrationsFolder: migrationsPath,
     })

--- a/apps/desktop/src/main/ipc/app.test.ts
+++ b/apps/desktop/src/main/ipc/app.test.ts
@@ -31,7 +31,6 @@ vi.mock('os', () => ({
 vi.mock('../models/app/index.js', () => ({
   isInitialized: vi.fn(),
   initializeApp: vi.fn(),
-  loadApp: vi.fn(),
 }))
 
 describe('App IPC Handlers', () => {
@@ -60,7 +59,6 @@ describe('App IPC Handlers', () => {
         expect.any(Function),
       )
       expect(mockIpcMain.handle).toHaveBeenCalledWith(CHANNELS.INITIALIZE_APP, expect.any(Function))
-      expect(mockIpcMain.handle).toHaveBeenCalledWith(CHANNELS.LOAD_APP, expect.any(Function))
     })
   })
 
@@ -152,26 +150,4 @@ describe('App IPC Handlers', () => {
     })
   })
 
-  describe('handleLoadApp', () => {
-    it('앱 로드 요청 시 성공적으로 로드되어야 함', async () => {
-      const { loadApp } = await import('../models/app/index.js')
-      vi.mocked(loadApp).mockResolvedValue(undefined)
-
-      registerAppHandlers(mockIpcMain)
-      const handler = getHandler(CHANNELS.LOAD_APP)
-
-      await expect(handler({} as Electron.IpcMainInvokeEvent)).resolves.not.toThrow()
-      expect(loadApp).toHaveBeenCalled()
-    })
-
-    it('앱 로드 실패 시 에러를 던져야 함', async () => {
-      const { loadApp } = await import('../models/app/index.js')
-      vi.mocked(loadApp).mockRejectedValue(new Error('Load failed'))
-
-      registerAppHandlers(mockIpcMain)
-      const handler = getHandler(CHANNELS.LOAD_APP)
-
-      await expect(handler({} as Electron.IpcMainInvokeEvent)).rejects.toThrow('Load failed')
-    })
-  })
 })

--- a/apps/desktop/src/main/ipc/app.ts
+++ b/apps/desktop/src/main/ipc/app.ts
@@ -7,12 +7,10 @@ import { CHANNELS } from '../../common/channel.const.js'
 /**
  * 디렉터리 선택 다이얼로그 (Documents 초기 경로)
  */
-async function openDirectoryDialog(
-  event: Electron.IpcMainInvokeEvent,
-): Promise<string | null> {
+async function openDirectoryDialog(event: Electron.IpcMainInvokeEvent): Promise<string | null> {
   const window = BrowserWindow.fromWebContents(event.sender)
 
-  const result = await dialog.showOpenDialog(window ?? undefined, {
+  const result = await dialog.showOpenDialog(window || undefined, {
     properties: ['openDirectory', 'createDirectory'],
     title: 'Select Workspace Location',
     buttonLabel: 'Select',
@@ -56,20 +54,6 @@ async function handleInitializeApp(
 }
 
 /**
- * 앱 로드 (일반 실행)
- */
-async function handleLoadApp(): Promise<void> {
-  try {
-    await AppModel.loadApp()
-  } catch (error: unknown) {
-    if (error instanceof Error) {
-      throw error
-    }
-    throw new Error('Failed to load app')
-  }
-}
-
-/**
  * 앱 관련 IPC 핸들러 등록
  */
 export default function registerAppHandlers(ipcMain: Electron.IpcMain): void {
@@ -81,7 +65,4 @@ export default function registerAppHandlers(ipcMain: Electron.IpcMain): void {
 
   // 앱 초기화 (첫 실행)
   ipcMain.handle(CHANNELS.INITIALIZE_APP, handleInitializeApp)
-
-  // 앱 로드 (일반 실행)
-  ipcMain.handle(CHANNELS.LOAD_APP, handleLoadApp)
 }

--- a/apps/desktop/src/main/models/app/const.ts
+++ b/apps/desktop/src/main/models/app/const.ts
@@ -2,9 +2,9 @@
  * 앱 레벨 경로 상수 (캡슐화됨)
  * 외부에서 직접 접근 불가, 경로 함수를 통해서만 사용
  */
-const APP_PATHS = {
+export const APP_PATHS = {
   CONFIG_FILE: 'config.json', // 앱 설정 (workspacePath 포함)
   CACHE_FILE: 'cache.db', // SQLite 캐시 (기존 database.sqlite에서 변경)
 } as const
 
-export { APP_PATHS }
+export const APP_VERSION = '1.0.0'

--- a/apps/desktop/src/main/models/app/index.test.ts
+++ b/apps/desktop/src/main/models/app/index.test.ts
@@ -1,28 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import fs from 'fs-extra'
-import { app } from 'electron'
-import {
-  getConfigPath,
-  getCachePath,
-  isInitialized,
-  loadAppConfig,
-  getAppConfig,
-  setAppConfig,
-  initializeApp,
-} from './index.js'
+import { isInitialized, initializeApp } from './index.js'
+import * as AppRepo from '../../repo/app/index.js'
 
-// Electron app mock
-vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn((key) => {
-      if (key === 'userData') return '/mock/userData'
-      if (key === 'cache') return '/mock/cache'
-      return '/mock/path'
-    }),
-  },
+vi.mock('../../repo/app/index.js', () => ({
+  exists: vi.fn(),
+  create: vi.fn(),
 }))
 
-vi.mock('fs-extra')
 vi.mock('./workspace/index.js', () => ({
   initializeWorkspace: vi.fn().mockResolvedValue(undefined),
 }))
@@ -30,91 +14,42 @@ vi.mock('./workspace/index.js', () => ({
 describe('App Model', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    setAppConfig(null)
   })
 
-  describe('getConfigPath', () => {
-    it('config 경로를 요청하면 userData 경로를 반환해야 함', () => {
-      const path = getConfigPath()
-      expect(path).toBe('/mock/userData/config.json')
-      expect(app.getPath).toHaveBeenCalledWith('userData')
-    })
-  })
-
-  describe('getCachePath', () => {
-    it('cache 경로를 요청하면 userData 경로를 반환해야 함', () => {
-      const path = getCachePath()
-      expect(path).toBe('/mock/userData/cache.db')
-      expect(app.getPath).toHaveBeenCalledWith('userData')
-    })
-  })
 
   describe('isInitialized', () => {
-    it('config 파일이 존재하면 true를 반환해야 함', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
+    it('AppRepo.exists가 true를 반환하면 true를 반환해야 함', async () => {
+      vi.mocked(AppRepo.exists).mockResolvedValue(true)
 
       const result = await isInitialized()
 
       expect(result).toBe(true)
-      expect(fs.pathExists).toHaveBeenCalledWith('/mock/userData/config.json')
+      expect(AppRepo.exists).toHaveBeenCalled()
     })
 
-    it('config 파일이 존재하지 않으면 false를 반환해야 함', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
+    it('AppRepo.exists가 false를 반환하면 false를 반환해야 함', async () => {
+      vi.mocked(AppRepo.exists).mockResolvedValue(false)
 
       const result = await isInitialized()
 
       expect(result).toBe(false)
+      expect(AppRepo.exists).toHaveBeenCalled()
     })
   })
 
-  describe('loadAppConfig', () => {
-    it('config 파일이 존재하면 로드하여 반환해야 함', async () => {
-      const mockConfig = { workspacePath: '/test/workspace' }
-      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
-      vi.mocked(fs.readJson).mockResolvedValue(mockConfig)
-
-      const config = await loadAppConfig()
-
-      expect(config).toEqual(mockConfig)
-      expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/config.json')
-      expect(getAppConfig()).toEqual(mockConfig)
-    })
-
-    it('config 파일이 존재하지 않으면 에러를 발생시켜야 함', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(false))
-
-      await expect(loadAppConfig()).rejects.toThrow(
-        'App configuration not found. Initialization required.',
-      )
-    })
-
-    it('workspacePath가 누락되면 에러를 발생시켜야 함', async () => {
-      vi.mocked(fs.pathExists).mockImplementation(() => Promise.resolve(true))
-      vi.mocked(fs.readJson).mockResolvedValue({})
-
-      await expect(loadAppConfig()).rejects.toThrow('Workspace path not configured.')
-    })
-  })
 
   describe('initializeApp', () => {
     it('워크스페이스 경로가 주어지면 앱을 초기화해야 함', async () => {
       const mockWorkspacePath = '/test/workspace'
-      vi.mocked(fs.writeJson).mockResolvedValue(undefined)
+      vi.mocked(AppRepo.create).mockResolvedValue(undefined)
 
       await initializeApp({ workspacePath: mockWorkspacePath })
 
-      // 설정 파일이 저장되었는지 확인
-      expect(fs.writeJson).toHaveBeenCalledWith(
-        '/mock/userData/config.json',
-        expect.objectContaining({
-          version: '1.0.0',
-          workspacePath: mockWorkspacePath,
-          createdAt: expect.any(String),
-          lastUsed: expect.any(String),
-        }),
-        { spaces: 2 },
-      )
+      // AppRepo.create가 호출되었는지 확인
+      expect(AppRepo.create).toHaveBeenCalledWith({
+        workspacePath: mockWorkspacePath,
+        version: '1.0.0',
+      })
 
       // 워크스페이스 초기화가 호출되었는지 확인
       const { initializeWorkspace } = await import('./workspace/index.js')
@@ -122,14 +57,4 @@ describe('App Model', () => {
     })
   })
 
-  describe('memory management', () => {
-    it('config 설정과 조회 시 메모리에서 관리되어야 함', () => {
-      expect(getAppConfig()).toBeNull()
-
-      const testConfig = { workspacePath: '/test/path' }
-      setAppConfig(testConfig)
-
-      expect(getAppConfig()).toEqual(testConfig)
-    })
-  })
 })

--- a/apps/desktop/src/main/models/app/index.ts
+++ b/apps/desktop/src/main/models/app/index.ts
@@ -1,80 +1,14 @@
-import { app } from 'electron'
-import { join } from 'path'
-import fs from 'fs-extra'
-import { APP_PATHS } from './const.js'
+import * as AppConst from './const.js'
 import { initializeWorkspace } from './workspace/index.js'
-import { initialize as initializeDB } from '../../db/index.js'
-
-/**
- * 앱 설정 파일 경로
- * @returns ~/Library/Application Support/voyl/config.json
- */
-export function getConfigPath(): string {
-  return join(app.getPath('userData'), APP_PATHS.CONFIG_FILE)
-}
-
-/**
- * SQLite 캐시 데이터베이스 경로
- * @returns ~/Library/Caches/voyl/cache.db (캐시 전용 디렉터리)
- */
-export function getCachePath(): string {
-  return join(app.getPath('userData'), APP_PATHS.CACHE_FILE)
-}
+import * as AppRepo from '../../repo/app/index.js'
 
 /**
  * 앱 초기화 상태 확인
  * 비동기로 통일하여 일관성 유지
  */
 export async function isInitialized(): Promise<boolean> {
-  const configPath = getConfigPath()
-  const exists = await fs.pathExists(configPath)
+  const exists = await AppRepo.exists()
   return exists
-}
-
-// 앱 설정 싱글톤 메모리 관리
-let appConfig: { workspacePath: string } | null = null
-
-/**
- * 메모리에서 앱 설정 조회 (싱글톤)
- */
-export function getAppConfig(): { workspacePath: string } | null {
-  return appConfig
-}
-
-/**
- * 메모리에 앱 설정 저장 (싱글톤)
- */
-export function setAppConfig(config: { workspacePath: string } | null): void {
-  appConfig = config
-}
-
-/**
- * 파일에서 앱 설정 로드하여 메모리에 저장
- */
-export async function loadAppConfig(): Promise<{ workspacePath: string }> {
-  const configPath = getConfigPath()
-  if (!(await fs.pathExists(configPath))) {
-    throw new Error('App configuration not found. Initialization required.')
-  }
-  const config = await fs.readJson(configPath)
-  if (!config.workspacePath) {
-    throw new Error('Workspace path not configured.')
-  }
-  setAppConfig(config)
-  return config
-}
-
-/**
- * 앱 설정 기반 워크스페이스 초기화 (IPC에서 호출)
- * @returns 초기화된 워크스페이스 경로
- */
-export async function initializeFromConfig(): Promise<string> {
-  const config = await loadAppConfig()
-
-  // 워크스페이스 초기화 (경로 검사 + 디렉터리 생성 + 설정)
-  await initializeWorkspace({ workspacePath: config.workspacePath })
-
-  return config.workspacePath
 }
 
 /**
@@ -82,35 +16,12 @@ export async function initializeFromConfig(): Promise<string> {
  * @param workspacePath 사용자가 선택한 경로
  */
 export async function initializeApp({ workspacePath }: { workspacePath: string }): Promise<void> {
-  // 1. 앱 설정을 파일에 저장
-  await saveAppConfigToFile({ workspacePath })
+  // 1. 앱 설정 생성
+  await AppRepo.create({
+    workspacePath,
+    version: AppConst.APP_VERSION,
+  })
   // 2. 워크스페이스 초기화 (폴더 구조 생성 + 권한 확인)
   await initializeWorkspace({ workspacePath })
   // 초기화 완료: DB 초기화는 loadApp()에서 별도로 수행
-}
-
-/**
- * 앱 로드 (설정 로드 + DB 초기화)
- */
-export async function loadApp(): Promise<void> {
-  // 1. config 파일에서 메모리로 로드 (이미 메모리에 있다면 파일에서 다시 로드)
-  await loadAppConfig()
-  // 2. 캐시 DB 초기화
-  const cachePath = getCachePath()
-  await initializeDB(cachePath)
-}
-
-/**
- * 앱 설정을 파일에 저장
- */
-export async function saveAppConfigToFile(config: { workspacePath: string }): Promise<void> {
-  const configPath = getConfigPath()
-  const fullConfig = {
-    version: '1.0.0',
-    workspacePath: config.workspacePath,
-    createdAt: new Date().toISOString(),
-    lastUsed: new Date().toISOString(),
-  }
-
-  await fs.writeJson(configPath, fullConfig, { spaces: 2 })
 }

--- a/apps/desktop/src/main/repo/app/const.ts
+++ b/apps/desktop/src/main/repo/app/const.ts
@@ -1,0 +1,5 @@
+import { app } from 'electron'
+import path from 'path'
+
+const FILE_NAME = 'config.json'
+export const PATH = path.join(app.getPath('userData'), FILE_NAME)

--- a/apps/desktop/src/main/repo/app/index.ts
+++ b/apps/desktop/src/main/repo/app/index.ts
@@ -1,0 +1,27 @@
+import * as db from '../db.js'
+import * as schema from './schema.js'
+import fs from 'fs-extra'
+import { PATH } from './const.js'
+
+export const exists = async (): Promise<boolean> => {
+  const ret = await db.connection.select().from(schema.app).limit(1)
+  return !!ret[0]
+}
+
+export const create = async ({
+  workspacePath,
+  version,
+}: {
+  workspacePath: string
+  version: string
+}): Promise<void> => {
+  await fs.writeJson(PATH, {
+    version,
+    workspacePath,
+  })
+
+  await db.connection.insert(schema.app).values({
+    version,
+    workspacePath,
+  })
+}

--- a/apps/desktop/src/main/repo/app/schema.ts
+++ b/apps/desktop/src/main/repo/app/schema.ts
@@ -1,0 +1,9 @@
+import { sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+export const app = sqliteTable('app', {
+  version: text('version').notNull().default('0.0.0'),
+  workspacePath: text('workspace_path'),
+})
+
+export type App = typeof app.$inferSelect
+export type NewApp = typeof app.$inferInsert

--- a/apps/desktop/src/main/repo/db.ts
+++ b/apps/desktop/src/main/repo/db.ts
@@ -1,0 +1,14 @@
+import Database from 'better-sqlite3'
+import { app } from 'electron'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import path from 'path'
+
+const DB_NAME = 'database.sqlite'
+const DB_PATH = path.join(app.getPath('userData'), DB_NAME)
+
+const sqlite = new Database(DB_PATH)
+sqlite.pragma('journal_mode = WAL')
+
+export const connection = drizzle(sqlite, {
+  logger: process.env.NODE_ENV === 'development',
+})

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,7 +7,6 @@ const api = {
   isInitialized: () => ipcRenderer.invoke(CHANNELS.IS_INITIALIZED),
   selectWorkspacePath: () => ipcRenderer.invoke(CHANNELS.SELECT_WORKSPACE_PATH),
   initializeApp: (path: string) => ipcRenderer.invoke(CHANNELS.INITIALIZE_APP, path),
-  loadApp: () => ipcRenderer.invoke(CHANNELS.LOAD_APP),
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/apps/desktop/src/renderer/store/app/index.ts
+++ b/apps/desktop/src/renderer/store/app/index.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
-import { selectWorkspacePath, initializeApp, loadApp } from '@/renderer/repos/app'
+import { selectWorkspacePath, initializeApp } from '@/renderer/repos/app'
 import { QUERY_KEYS } from './const.js'
 import { getInitializationQueryOptions } from './queryOptions.js'
 
@@ -29,10 +29,7 @@ export function useInitializeWorkspace() {
 
   return useMutation({
     mutationFn: async (path: string) => {
-      // 1. 초기화 (설정 생성 + 워크스페이스 폴더 생성)
       await initializeApp(path)
-      // 2. 로드 (DB 초기화 등)
-      await loadApp()
       return true
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- Repo 계층을 도입하여 데이터 저장소 추상화
- AppRepo를 통한 앱 설정 관리 구현
- 기존 Model 코드를 Repo 패턴으로 리팩토링

## Changes

### 1. Repo 인프라 구축
- `main/repo/` 디렉토리 구조 추가
- `AppRepo` 구현 (SQLite + 파일시스템 하이브리드 저장)
- ESLint 규칙에 repo 디렉토리 추가

### 2. AppModel 리팩토링
- 파일 직접 접근 제거
- `AppRepo.exists()`, `create()` 메서드 사용
- 메모리 캐싱 로직 제거

### 3. 불필요한 코드 정리
- `loadApp` 함수 및 관련 테스트 제거
- `CHANNELS.LOAD_APP` 채널 제거
- 관련 IPC 핸들러 정리

## Test Plan
- [x] 유닛 테스트 통과
- [ ] 앱 초기화 테스트
- [ ] 워크스페이스 설정 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)